### PR TITLE
Setup the pipeline for publishing to Galaxy and AH

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ variables:
   ChocoCIClient.ansibleUser: 'ansible-test'
 # ChocoCIClient.ansiblePassword: <secret>
   collectionArtifactName: 'chocolatey.collection'
+  Package.Version: 24.6.26
 
 trigger:
   batch: true
@@ -67,6 +68,24 @@ stages:
       inputs:
         targetType: filePath
         filePath: ./build/dependencies.sh
+
+    - task: PowerShell@2
+      displayName: 'Set Package Version'
+
+      inputs:
+        targetType: 'inline'
+        script: |
+          $tagName = if ("$(Build.SourceBranch)" -match '^/refs/tags/(?<Tag>.+)') {
+              $matches.Tag
+          }
+          else {
+              "$env:PACKAGE_VERSION-$(Get-Date -Format 'yyyyMMdd')-$(New-Guid)"
+          }
+          Write-Host "##vso[task.setvariable variable=Package.Version]$tagName"
+
+        errorActionPreference: 'stop'
+        failOnStderr: true
+        pwsh: true
 
     - task: AzureCLI@2
       displayName: 'Run Ansible-Test for Collection'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,12 +147,12 @@ stages:
       displayName: 'Publish Chocolatey Collection to Galaxy'
       inputs:
         targetType: filePath
-        filePath: ./build/Publish-Collection.ps1 -UserName $(GalaxyUsername) -Secret $(GalaxyPassword)
+        filePath: ./build/Publish-Collection.ps1 -ApiKey $(GalaxyApiKey)
         pwsh: true
 
     - task: PowerShell@2
       displayName: 'Publish Chocolatey Collection to AH'
       inputs:
         targetType: filePath
-        filePath: ./build/Publish-Collection.ps1 -UserName $(AHUsername) -Secret $(AHPassword) -Url $(AHUrl)
+        filePath: ./build/Publish-Collection.ps1 -ApiKey $(AHApiKey) -Url $(AHUrl)
         pwsh: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,6 +170,7 @@ stages:
         pwsh: true
 
     - task: PowerShell@2
+      enabled: false # pending AH access
       displayName: 'Publish Chocolatey Collection to AH'
       inputs:
         targetType: filePath

--- a/build/Invoke-CollectionTests.ps1
+++ b/build/Invoke-CollectionTests.ps1
@@ -66,6 +66,8 @@ process {
             )
 
             $Inventory | Set-Content -Path './chocolatey/tests/integration/ci-inventory.winrm'
+            (Get-Content -Path './chocolatey/galaxy.yml' -Raw) -replace '{{ REPLACE_VERSION }}', $env:PACKAGE_VERSION |
+                Set-Content -Path './chocolatey/galaxy.yml'
             bash -c $Commands
 
             # Locate the built tarball and expose the path & name in Azure variables
@@ -81,6 +83,7 @@ process {
                 throw "An error has occurred; please refer to the Vagrant log for details."
             }
 
+            vagrant ssh choco_ansible_server --command "sed -i ./chocolatey/galaxy.yml 's/{{ REPLACE_VERSION }}/$env:PACKAGE_VERSION/g'"
             vagrant ssh choco_ansible_server --command $Commands
             $Result = [PSCustomObject]@{
                 Success  = $?

--- a/chocolatey/galaxy.yml
+++ b/chocolatey/galaxy.yml
@@ -9,7 +9,7 @@ namespace: chocolatey
 name: chocolatey
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: {{ REPLACE_VERSION }}
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
This configuration is sufficient for publishing to Galaxy. Additional variables need to be defined in the pipeline for AH publishing.

Currently this publish will trigger when a commit is tagged in the repo.