### PR TITLE
(GH-8) Fix invalid argument assignment

### DIFF
--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -632,7 +632,7 @@ Function Uninstall-ChocolateyPackage {
         $arguments.Add("--force") > $null
     }
     if ($package_params) {
-        $arguments.Add("--package-params") > $null
+        $arguments.Add("--package-parameters") > $null
         $arguments.Add($package_params) > $null
     }
     if ($skip_scripts) {


### PR DESCRIPTION
Previously the Uninstall would add the incorrect argument.

Without this change the uninstall script will not function properly
with the package_params argument

Fixes #8