### PR TITLE
Rework pipeline for AH/Galaxy publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,6 +143,8 @@ stages:
   displayName: '[Publish]'
   dependsOn: Build
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+  variables:
+    ansibleConfigPath: '~/ansible.cfg'
 
   jobs:
   - job: Publish
@@ -172,7 +174,7 @@ stages:
           $config = Get-Content -Path ./build/ansible.cfg -Raw
           $config = $config -replace '{{ REPLACE_GALAXY_TOKEN }}', '$(GalaxyApiKey)' -replace '{{ REPLACE_AH_TOKEN }}', '$(AHApiKey)'
 
-          $path = '~/ansible.cfg'
+          $path = $(ansibleConfigPath)
           Write-Host "Copying Ansible publishing configuration to '$path'"
           $config | Set-Content -Path $path
 
@@ -183,4 +185,4 @@ stages:
         targetType: filePath
         filePath: ./build/Publish-Collection.ps1
       env:
-        ANSIBLE_CONFIG: '~/ansible.cfg'
+        ANSIBLE_CONFIG: $(ansibleConfigPath)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,4 +185,6 @@ stages:
         targetType: filePath
         filePath: ./build/Publish-Collection.ps1
       env:
-        ANSIBLE_CONFIG: $(ansibleConfigPath)
+        ANSIBLE_CONFIG: '$(System.DefaultWorkingDirectory)/build/ansible.cfg'
+        ANSIBLE_GALAXY_SERVER_RELEASE_GALAXY_TOKEN: '$(GalaxyApiKey)'
+        ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN: '$(AHApiKey)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,17 +164,23 @@ stages:
         targetPath: '$(System.DefaultWorkingDirectory)/artifacts/'
 
     - task: PowerShell@2
-      displayName: 'Publish Chocolatey Collection to Galaxy'
+      displayName: 'Setup ansible.cfg'
       inputs:
-        targetType: filePath
-        filePath: ./build/Publish-Collection.ps1
-        arguments: -ApiKey $(GalaxyApiKey)
         pwsh: true
+        targetType: inline
+        script: |
+          $config = Get-Content -Path ./build/ansible.cfg -Raw
+          $config = $config -replace '{{ REPLACE_GALAXY_TOKEN }}', '$(GalaxyApiKey)' -replace '{{ REPLACE_AH_TOKEN }}', '$(AHApiKey)'
+
+          $path = '~/ansible.cfg'
+          Write-Host "Copying Ansible publishing configuration to '$path'"
+          $config | Set-Content -Path $path
 
     - task: PowerShell@2
-      displayName: 'Publish Chocolatey Collection to AH'
+      displayName: 'Publish Chocolatey Collection to Galaxy & AH'
       inputs:
+        pwsh: true
         targetType: filePath
         filePath: ./build/Publish-Collection.ps1
-        arguments: -ApiKey $(AHApiKey) -Url $(AHUrl)
-        pwsh: true
+      env:
+        ANSIBLE_CONFIG: '~/ansible.cfg'

--- a/build/ansible.cfg
+++ b/build/ansible.cfg
@@ -1,12 +1,9 @@
 [galaxy]
-server_list = ansible_galaxy, automation_hub
+server_list = release_galaxy, automation_hub
 
-[galaxy_server.ansible_galaxy]
+[galaxy_server.release_galaxy]
 url=https://galaxy.ansible.com/
-token={{ REPLACE_GALAXY_TOKEN }}
 
 [galaxy_server.automation_hub]
 url=https://cloud.redhat.com/api/automation-hub/
 auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-
-token={{ REPLACE_AH_TOKEN }}

--- a/build/ansible.cfg
+++ b/build/ansible.cfg
@@ -1,0 +1,12 @@
+[galaxy]
+server_list = ansible_galaxy, automation_hub
+
+[galaxy_server.ansible_galaxy]
+url=https://galaxy.ansible.com/
+token={{ REPLACE_GALAXY_TOKEN }}
+
+[galaxy_server.automation_hub]
+url=https://cloud.redhat.com/api/automation-hub/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+token={{ REPLACE_AH_TOKEN }}


### PR DESCRIPTION
## Summary

Reworked pipeline using documentation from Ansible around publishing:
https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#galaxy-server-config

## Changes

- Added `ansible.cfg` with some placeholder values for API keys
- Added step to publishing pipeline to create an `ansible.cfg` file before publishing, using the template file and replacing the placeholder values with Azure Pipelines variables (already configured via Azure DevOps Pipelines).
- Consolidated the two publishing steps into a single step which should publish to both servers (if I'm reading documentation correctly).