### PR TITLE
Quote replacement yaml text for git installs

### DIFF
--- a/chocolatey/galaxy.yml
+++ b/chocolatey/galaxy.yml
@@ -9,7 +9,7 @@ namespace: chocolatey
 name: chocolatey
 
 # The version of the collection. Must be compatible with semantic versioning
-version: {{ REPLACE_VERSION }}
+version: '{{ REPLACE_VERSION }}'
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Adds support for installing this collection as a git repo source based on the changes in https://github.com/ansible/ansible/pull/69154.

The changes proposed in the PR 69154 requires the `galaxy.yml` in the git repo to be valid yaml. Having these quotes will allow people to install this collection for unpublished builds for local testing or development if that is desired.