### PR TITLE
(#22) Fallback to default choco path

### DIFF
--- a/chocolatey/plugins/modules/win_chocolatey_config.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_config.ps1
@@ -92,6 +92,13 @@ Function Set-ChocolateyConfig {
 }
 
 $choco_app = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
+if ($null -eq $choco_app) {
+    $choco_dir = $env:ChocolateyInstall
+    if ($null -eq $choco_dir) {
+        $choco_dir = "$env:SYSTEMDRIVE\ProgramData\Chocolatey"
+    }
+    $choco_app = Get-Command -Name "$choco_dir\bin\choco.exe" -CommandType Application -ErrorAction SilentlyContinue
+}
 if (-not $choco_app) {
     Fail-Json -obj $result -message "Failed to find Chocolatey installation, make sure choco.exe is in the PATH env value"
 }

--- a/chocolatey/plugins/modules/win_chocolatey_facts.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_facts.ps1
@@ -27,6 +27,13 @@ $result = @{
 }
 
 $choco_app = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
+if ($null -eq $choco_app) {
+    $choco_dir = $env:ChocolateyInstall
+    if ($null -eq $choco_dir) {
+        $choco_dir = "$env:SYSTEMDRIVE\ProgramData\Chocolatey"
+    }
+    $choco_app = Get-Command -Name "$choco_dir\bin\choco.exe" -CommandType Application -ErrorAction SilentlyContinue
+}
 if (-not $choco_app) {
     Fail-Json -obj $result -message "Failed to find Chocolatey installation, make sure choco.exe is in the PATH env value"
 }

--- a/chocolatey/plugins/modules/win_chocolatey_feature.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_feature.ps1
@@ -55,6 +55,13 @@ Function Set-ChocolateyFeature {
 }
 
 $choco_app = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
+if ($null -eq $choco_app) {
+    $choco_dir = $env:ChocolateyInstall
+    if ($null -eq $choco_dir) {
+        $choco_dir = "$env:SYSTEMDRIVE\ProgramData\Chocolatey"
+    }
+    $choco_app = Get-Command -Name "$choco_dir\bin\choco.exe" -CommandType Application -ErrorAction SilentlyContinue
+}
 if (-not $choco_app) {
     Fail-Json -obj $result -message "Failed to find Chocolatey installation, make sure choco.exe is in the PATH env value"
 }

--- a/chocolatey/plugins/modules/win_chocolatey_source.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_source.ps1
@@ -209,6 +209,14 @@ Function Remove-ChocolateySource {
 }
 
 $choco_app = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
+if ($null -eq $choco_app) {
+    $choco_dir = $env:ChocolateyInstall
+    if ($null -eq $choco_dir) {
+        $choco_dir = "$env:SYSTEMDRIVE\ProgramData\Chocolatey"
+    }
+    $choco_app = Get-Command -Name "$choco_dir\bin\choco.exe" -CommandType Application -ErrorAction SilentlyContinue
+}
+
 if (-not $choco_app) {
     Fail-Json -obj $result -message "Failed to find Chocolatey installation, make sure choco.exe is in the PATH env value"
 }


### PR DESCRIPTION
Due to an issue in Win32-OpenSSH (see PowerShell/Win32-OpenSSH#1329) a fallback is necessary in all of these plugins, as the environment variables will not be updated after installing choco until the SSHD session is restarted or the system is rebooted.

This PR adds a similar fallback to the other plugins that already exists in `win_chocolatey` where it will fall back to the default install path.

As the installation method used in win_chocolatey doesn't currently allow for Chocolatey to be installed to a non-default path this workaround should be sufficient for the time being. It can be revisited in future if we modify the Chocolatey installation behaviour to allow users to specify where Chocolatey is installed to.

Resolves #22 