### PR TITLE
Add timestamp to VM name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,18 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
+    - task: PowerShell@2
+      displayName: 'Set VM Name'
+
+      inputs:
+        targetType: 'inline'
+        script: |
+          Write-Host "##vso[task.setvariable variable=ChocoCIClient.labVMName]$(Get-Date -AsUtc -Format "CyyyyMMddHHmmss")"
+
+        errorActionPreference: 'stop'
+        failOnStderr: true
+        pwsh: true
+
     - task: AzureDevTestLabsCreateVM@3
       name: AzureVM
       displayName: 'Create Azure Labs VM'


### PR DESCRIPTION
This change lets us timestamp the VM names we're using so that Azure's plugins don't find a VM being used by a different PR if they happen to be filed / updated at similar times.

The VM name limit is 15 chars, so we basically only have room for the timestamp and nothing more. c'est la vie.

EDIT: They're _very_ picky about their VM names, apparently. Think I got it sorted for now though.