### PR TITLE
(#21) :bug: Remove --allow-multiple for uninstall

### DIFF
--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -1,8 +1,16 @@
 #!/bin/sh
 
+sudo add-apt-repository universe
+sudo apt update
 sudo apt-get update
 
 sudo apt-get install python3 python3-pip python3-venv python3-dev -y
+sudo apt install python2
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+sudo python2 get-pip.py
+
+pip2 --version
+pip3 --version
 
 python3 -m venv ~/ansible-venv
 source ~/ansible-venv/bin/activate

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -649,8 +649,6 @@ Function Uninstall-ChocolateyPackage {
         $arguments.Add($timeout) > $null
     }
     if ($version) {
-        # Need to set allow-multiple to make sure choco doesn't uninstall all versions
-        $arguments.Add("--allow-multiple") > $null
         $arguments.Add("--version") > $null
         $arguments.Add($version) > $null
     } else {
@@ -807,4 +805,3 @@ if ($state -in @("downgrade", "latest", "present", "reinstalled")) {
 }
 
 $module.ExitJson()
-

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -631,28 +631,33 @@ Function Uninstall-ChocolateyPackage {
     $common_args = Get-CommonChocolateyArguments
     $arguments.AddRange($common_args)
 
-    if ($force) {
-        $arguments.Add("--force") > $null
-    }
-    if ($package_params) {
-        $arguments.Add("--package-parameters") > $null
-        $arguments.Add($package_params) > $null
-    }
-    if ($skip_scripts) {
-        $arguments.Add("--skip-scripts") > $null
-    }
-    if ($remove_dependencies) {
-        $arguments.Add("--remove-dependencies") > $null
-    }
-    if ($null -ne $timeout) {
-        $arguments.Add("--timeout") > $null
-        $arguments.Add($timeout) > $null
-    }
     if ($version) {
         $arguments.Add("--version") > $null
         $arguments.Add($version) > $null
     } else {
         $arguments.Add("--all-versions") > $null
+    }
+
+    if ($remove_dependencies) {
+        $arguments.Add("--remove-dependencies") > $null
+    }
+
+    if ($force) {
+        $arguments.Add("--force") > $null
+    }
+
+    if ($null -ne $timeout) {
+        $arguments.Add("--timeout") > $null
+        $arguments.Add($timeout) > $null
+    }
+
+    if ($skip_scripts) {
+        $arguments.Add("--skip-scripts") > $null
+    }
+
+    if ($package_params) {
+        $arguments.Add("--package-parameters") > $null
+        $arguments.Add($package_params) > $null
     }
 
     $command = Argv-ToString -arguments $arguments

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -480,8 +480,8 @@
   assert:
     that:
     - allow_multiple is changed
-    - '"ansible|0.1.0" in allow_multiple_actual.stdout_lines'
-    - '"ansible|0.0.1" in allow_multiple_actual.stdout_lines'
+    - '"{{ test_choco_package1 }}|0.1.0" in allow_multiple_actual.stdout_lines'
+    - '"{{ test_choco_package1 }}|0.0.1" in allow_multiple_actual.stdout_lines'
 
 - name: pin 2 packages (check mode)
   win_chocolatey:

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -606,5 +606,5 @@
   assert:
     that:
     - remove_multiple is changed
-    - '"ansible|0.0.1" not in remove_multiple_actual.stdout_lines'
-    - '"ansible|0.1.0" in remove_multiple_actual.stdout_lines'
+    - '"{{ test_choco_package1 }}|0.0.1" not in remove_multiple_actual.stdout_lines'
+    - '"{{ test_choco_package1 }}|0.1.0" in remove_multiple_actual.stdout_lines'


### PR DESCRIPTION
This is a workaround for chocolatey/choco#2101. 

On uninstall, we can't use `--allow-multiple` unilaterally; it breaks the uninstall when there is only a single package version installed.

So there are now two states, neither of which should be exposed as configurable in my opinion, because it would simply allow users to break things, and not give them any utility. `allow_multiple:` from Ansible will still be ignored completely for `state: absent` requests, and the module will apply it as is required.

Basically, the flow is now this (for `state: absent` specifically):

1. If there are multiple package versions installed:
    a. If a specific version is NOT specified, do not pass `--allow-multiple` either, and choco will uninstall all versions of the package that are currently installed.
    b. If a specific version IS specified, pass the version in addition to `--allow-multiple` to allow just that single version to be uninstalled.
2. If there is only one package version actually installed, simply do not pass `--allow-multiple` under any circumstance. Passing the flag with the system in this state does nothing useful and only breaks the usage of the command.

Resolves #21