### PR TITLE
(#35) Fix state:absent for specific versions

### DIFF
--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -9,10 +9,14 @@ sudo apt install python2
 curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
 sudo python2 get-pip.py
 
-pip2 --version
-pip3 --version
+
 
 python3 -m venv ~/ansible-venv
 source ~/ansible-venv/bin/activate
+
+pip3 --version
 pip3 install --upgrade wheel
 pip3 install ansible pywinrm
+
+pip2 --version
+pip2 install --upgrade wheel

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -608,3 +608,20 @@
     - remove_multiple is changed
     - '"{{ test_choco_package1 }}|0.0.1" not in remove_multiple_actual.stdout_lines'
     - '"{{ test_choco_package1 }}|0.1.0" in remove_multiple_actual.stdout_lines'
+
+- name: attempt to uninstall a nonexistent version of an installed package
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: absent
+    version: '2.0.12'
+  register: remove_nonexistent_version
+
+- name: get result of uninstall a nonexistent version of an installed package
+  win_command: choco.exe list --local-only --limit-output --all-versions
+  register: remove_nonexistent_version_result
+
+- name: assert uninstall of nonexistent version of an installed package
+  assert:
+    that:
+    - not remove_nonexistent_version is changed
+    - '"{{ test_choco_package1 }}|0.1.0" in remove_nonexistent_version_result.stdout_lines'


### PR DESCRIPTION
Previously, specifying a direct version would have choco error out with either `state: absent` or `state: reinstalled` if that specific version isn't actually installed, which we don't want.

Fixed by allowing the version value provided to be passed through to the choco list command, which will allow us to filter down to only target installed _versions_ of packages, if desired.

When `state:absent` is supplied along with a target version, module will no-op when that version is not already installed.

Fixes #35