### PR TITLE
(#18) Use more versatile URL handling for getting the chocolatey install script URL

### DIFF
--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -249,7 +249,7 @@ Function Install-Chocolatey {
 
         if ($source) {
             # check if the URL already contains the path to PS script
-            if ($source.EndsWith(".ps1")) {
+            if ($source -like "*.ps1") {
                 $script_url = $source
             } else {
                 # chocolatey server automatically serves a script at

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -248,17 +248,20 @@ Function Install-Chocolatey {
         }
 
         if ($source) {
+            $uri_info = [System.Uri]$source
+
             # check if the URL already contains the path to PS script
             if ($source -like "*.ps1") {
                 $script_url = $source
-            } else {
+            } elseif ($uri_info.AbsolutePath -like '/repository/*') {
+                $script_url = "$($uri_info.Scheme)://$($uri_info.Authority)/$($uri_info.AbsolutePath)/install.ps1" -replace '//','/'
+            }else {
                 # chocolatey server automatically serves a script at
                 # http://host/install.ps1, we rely on this behaviour when a
-                # user specifies the choco source URL. If a custom URL or file
-                # path is desired, they should use win_get_url/win_shell
-                # manually
-                # we need to strip the path off the URL and append install.ps1
-                $uri_info = [System.Uri]$source
+                # user specifies the choco source URL and it doesn't look like a repository style url.
+                # If a custom URL or file path is desired, they should use win_get_url/win_shell
+                # manually.
+                # We need to strip the path off the URL and append install.ps1
                 $script_url = "$($uri_info.Scheme)://$($uri_info.Authority)/install.ps1"
             }
             if ($source_username) {

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -255,7 +255,7 @@ Function Install-Chocolatey {
                 $script_url = $source
             } elseif ($uri_info.AbsolutePath -like '/repository/*') {
                 $script_url = "$($uri_info.Scheme)://$($uri_info.Authority)/$($uri_info.AbsolutePath)/install.ps1" -replace '//','/'
-            }else {
+            } else {
                 # chocolatey server automatically serves a script at
                 # http://host/install.ps1, we rely on this behaviour when a
                 # user specifies the choco source URL and it doesn't look like a repository style url.


### PR DESCRIPTION
Two main improvements have been made in this PR:

1. When checking the URL ends with `.ps1`, make sure we use a non-case-sensitive check (i.e., a URL of the form `https://server.com/example/chocolatey.PS1` should still work.
2. If it doesn't end in PS1, look for known patterns in the URL, like the common Nexus pattern of `/repository/*` which indicates the script should look in a specific repository, rather than just assuming the script is definitely hosted in the server root.

This resolves #18 at least for some of the common cases. We can add more complex handling here if needed in future.