### PR TITLE
Fix win_chocolatey_source tests to allow for test reruns to work correctly

### DIFF
--- a/chocolatey/tests/integration/targets/win_chocolatey_facts/tasks/main.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey_facts/tasks/main.yml
@@ -17,7 +17,6 @@
     source_password: password
     certificate: C:\temp\cert.pfx
 
-
 - name: set a config value
   win_chocolatey_config:
     name: proxyUser

--- a/chocolatey/tests/integration/targets/win_chocolatey_source/tasks/main.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey_source/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: remove original Chocolatey source at the start of the test
   win_chocolatey_source:
-    name: Chocolatey
+    name: chocolatey
     state: absent
 
 - name: ensure test Chocolatey source is removed
@@ -21,7 +21,7 @@
   always:
   - name: ensure original Chocolatey source is re-added
     win_chocolatey_source:
-      name: Chocolatey
+      name: chocolatey
       source: https://chocolatey.org/api/v2/
       state: present
 


### PR DESCRIPTION
The win_chocolatey_source tests re-added the default source with a capital C in the name, which doesn't match the normal default (all lowercase).

This causes other tests to fail on a rerun, as the source name is now different than expected.

Fix is to ensure we re-add the source name in lowercase.

This should also allow us to test against multiple Ansible versions, reusing the same Windows VM for all the integration tests before destroying it.

Fixes #47 