### PR TITLE
Add runtime.yml

### DIFF
--- a/chocolatey/meta/runtime.yml
+++ b/chocolatey/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: '>=2.9.0'


### PR DESCRIPTION
Ansible collections should define a minimum Ansible versions in a meta/runtime.yml file in the collection directory.

This PR adds the file and sets the minimum Ansible version to 2.9.0, in keeping with most collections and recommendations from Ansible folks who know much better than I do ;)

Fixes #45 