### PR TITLE
(maint) Add templates and supporting docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/SecurityDisclosure.md
+++ b/.github/ISSUE_TEMPLATE/SecurityDisclosure.md
@@ -1,0 +1,8 @@
+---
+name: Security Disclosure / Report
+about: Found a security issue?
+---
+
+STOP RIGHT HERE - DO NOT CREATE A TICKET FOR A SECURITY FINDING IN THE OPEN (HERE OR IN ANY COMMUNITY)
+
+Security reports should never start out in the open. Please follow up directly with the team if you have a contact. If not you can always start with the information at https://chocolatey.org/security to see instructions on how to provide the disclosure. Thank you!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/yReportIssue.md
+++ b/.github/ISSUE_TEMPLATE/yReportIssue.md
@@ -1,0 +1,60 @@
+---
+name: Bug Report
+about: Did you find unexpected behavior?
+title: ''
+labels: 0 - _Triaging, Bug
+assignees: ''
+---
+
+Ensure you have read over Submitting Issues -
+https://github.com/chocolatey/chocolatey-ansible/blob/master/README.md#submitting-issues
+
+Please check to see if your issue already exists with a quick search of the issues. Start with one relevant term and then add if you get too many results.
+
+NOTE: Keep in mind we have an etiquette regarding communication that we expect folks to observe when they are looking for support in the Chocolatey community. https://github.com/chocolatey/chocolatey-ansible/blob/master/README.md#etiquette-regarding-communication
+-->
+
+## Expected Behavior
+
+## Current Behavior
+
+## Possible Solution / Workaround
+
+## Steps to Reproduce
+
+1.
+1.
+1.
+1.
+
+## Context (Environment)
+
+* Ansible version: 
+* Chocolatey Collection version: 
+* Windows version: 
+* Chocolatey version: 
+* Chocolatey Extension version: 
+
+### Output Log
+<!--
+When including the log information, please ensure you have run the command with --debug --verbose. It provides important information for determining an issue
+
+- Make sure there is no sensitive data shared.
+- We need ALL output, not just what you may believe is relevant.
+- We need ALL OUTPUT (including the configuration information), see https://gist.github.com/ferventcoder/b1300b91c167c8ac8205#file-error-txt-L1-L41 for what we need.
+- If it is hard to reproduce with debug/verbose, the log file already logs with those parameters, just grab the relevant section from the log file (in the logs directory of your Chocolatey install).
+-->
+
+
+<details>
+<summary>Full Log Output</summary>
+
+<p>
+
+~~~sh
+PLACE LOG CONTENT HERE - WE NEED _ALL_ DETAILED OUTPUT BASED ON THE ABOVE TO BE ABLE TO PROVIDE SUPPORT (YOU WILL FIND THAT IN THE $env:ChocolateyInstall\logs\chocolatey.log between the `=====`)
+~~~
+
+</p>
+
+</details>

--- a/.github/ISSUE_TEMPLATE/zFeatureRequest.md
+++ b/.github/ISSUE_TEMPLATE/zFeatureRequest.md
@@ -1,0 +1,28 @@
+---
+name: Feature / Enhancement Request
+about: Suggest an idea for improving the Chocolatey Ansible collection.
+title: ''
+labels: 0 - _Triaging, Enhancement
+assignees: ''
+---
+
+<!--
+Please observe https://github.com/chocolatey/chocolatey-ansible/blob/master/CONTRIBUTING.md guidelines prior to creating your issue.
+
+NOTE: Keep in mind we have an etiquette regarding communication that we expect folks to observe when they are looking for support in the Chocolatey community. https://github.com/chocolatey/chocolatey-ansible/blob/master/README.md#etiquette-regarding-communication
+-->
+
+## Motivation and Context
+<!--
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+-->
+
+## Solution
+<!--
+A clear and concise description of what you want to happen.
+-->
+
+## Additional Context
+<!--
+Add any other context or screenshots about the feature request here.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+<!--
+BEFORE YOU CREATE A PULL REQUEST:
+
+Provide a general summary of your changes in the Title above with the format `(#<ISSUE NUMBER>) Title`
+
+Ensure you have read over CONTRIBUTING - https://github.com/chocolatey/chocolatey-ansible/blob/master/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).
+
+A summary of our expectations:
+ - You are not submitting a pull request from your MASTER branch.
+ - You are able to sign the Contributor License Agreement (CLA).
+ - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
+ - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.
+- You have raised an issue for discussion and had it accepted by a member of the Chocolatey team before creating a Pull Request
+
+THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.
+
+DELETE EVERYTHING IN THIS COMMENT BLOCK
+-->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+Fixes #
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--
+Go over all the following points, and put an `x` in all the boxes that apply.
+If you're unsure about any of these, don't hesitate to ask. We're here to help!
+-->
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests pass.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,203 @@
+# Contributing
+The Chocolatey team has very explicit information here regarding the process for contributions, and we will be sticklers about the way you write your commit messages (yes, really), so to save yourself some rework, please make sure you read over this entire document prior to contributing.
+
+<!-- TOC -->
+
+- [Are You In the Right Place?](#are-you-in-the-right-place)
+  - [Reporting an Issue/Bug?](#reporting-an-issuebug)
+    - [SolutionVersion.cs](#solutionversioncs)
+  - [Package Issue?](#package-issue)
+  - [Package Request? Package Missing?](#package-request-package-missing)
+  - [Submitting an Enhancement / Feature Request?](#submitting-an-enhancement--feature-request)
+    - [Submitting an Enhancement For Choco](#submitting-an-enhancement-for-choco)
+- [Contributing](#contributing)
+  - [Prerequisites](#prerequisites)
+    - [Definition of Trivial Contributions](#definition-of-trivial-contributions)
+    - [Is the CLA Really Required?](#is-the-cla-really-required)
+- [Contributing Process](#contributing-process)
+  - [Get Buyoff Or Find Open Community Issues/Features](#get-buyoff-or-find-open-community-issuesfeatures)
+  - [Set Up Your Environment](#set-up-your-environment)
+  - [Code Format / Design](#code-format--design)
+    - [CSharp](#csharp)
+    - [PowerShell](#powershell)
+  - [Debugging / Testing](#debugging--testing)
+    - [Visual Studio](#visual-studio)
+      - [Automated Tests](#automated-tests)
+    - [Chocolatey Build](#chocolatey-build)
+  - [Prepare Commits](#prepare-commits)
+  - [Submit Pull Request (PR)](#submit-pull-request-pr)
+  - [Respond to Feedback on Pull Request](#respond-to-feedback-on-pull-request)
+- [Other General Information](#other-general-information)
+
+<!-- /TOC -->
+
+## Are You In the Right Place?
+Chocolatey is a large ecosystem and each component has their own location for submitting issues and enhancement requests. This is the repository for Chocolatey Ansible collection.
+
+Please follow this decision criteria to see if you are in the right location or if you should head to a different location to submit your request.
+
+### Reporting an Issue/Bug?
+
+Submitting an Issue (or a Bug)? See the **[Submitting Issues](https://github.com/chocolatey/chocolatey-ansible/tree/master/README.md#submitting-issues) section** in the README.
+
+### Package Issue?
+
+Please see [Request Package Fixes or Updates / Become a maintainer of an existing package](https://chocolatey.org/docs/package-triage-process).
+
+### Submitting an Enhancement / Feature Request?
+
+If this is for Chocolatey Ansible collection, this is the right place. See below. Otherwise see [Submitting Issues](https://github.com/chocolatey/chocolatey-ansible/tree/master/README.md#submitting-issues).
+
+## Contributing
+
+The process for contributions is roughly as follows:
+
+### Prerequisites
+
+ * Submit an [issue](https://github.com/chocolatey/chocolatey-ansible/issues). You will need the issue id for your commits.
+ * Ensure you have signed the Contributor License Agreement (CLA) - without this we are not able to take contributions that are not trivial.
+  * [Sign the Contributor License Agreement](https://www.clahub.com/agreements/chocolatey/choco).
+  * You must do this for each Chocolatey project that requires it.
+  * If you are curious why we would require a CLA, we agree with Julien Ponge - take a look at his [post](https://julien.ponge.org/blog/in-defense-of-contributor-license-agreements/).
+ * You agree to follow the [etiquette regarding communication](https://github.com/chocolatey/choco#etiquette-regarding-communication).
+
+#### Definition of Trivial Contributions
+It's hard to define what is a trivial contribution. Sometimes even a 1 character change can be considered significant. Unfortunately because it can be subjective, the decision on what is trivial comes from the committers of the project and not from folks contributing to the project. It is generally safe to assume that you may be subject to signing the [CLA](https://www.clahub.com/agreements/chocolatey/choco) and be prepared to do so. Ask in advance if you are not sure and for reasons are not able to sign the [CLA](https://www.clahub.com/agreements/chocolatey/choco).
+
+What is generally considered trivial:
+
+* Fixing a typo
+* Documentation changes
+* Fixes to non-production code - like fixing something small in the build code.
+
+What is generally not considered trivial:
+
+ * Changes to any code that would be delivered as part of the final product. This includes any scripts that are delivered, such as PowerShell scripts. Yes, even 1 character changes could be considered non-trivial.
+
+#### Is the CLA Really Required?
+
+Yes, and this aspect is not up for discussion. If you would like more resources on understanding CLAs, please see the following articles:
+
+* [What is a CLA and why do I care?](https://www.clahub.com/pages/why_cla)
+* [In defense of Contributor License Agreements](https://julien.ponge.org/blog/in-defense-of-contributor-license-agreements/)
+* [Contributor License Agreements](http://oss-watch.ac.uk/resources/cla)
+* Dissenting opinion - [Why your project doesn't need a Contributor License Agreement](https://sfconservancy.org/blog/2014/jun/09/do-not-need-cla/)
+
+Overall, the flexibility and legal protections provided by a CLA make it necessary to require a CLA. As there is a company and a licensed version behind Chocolatey, those protections must be afforded. We understand this means some folks won't be able to contribute and that's completely fine. We prefer you to know up front this is required so you can make the best decision about contributing.
+
+If you work for an organization that does not allow you to contribute without attempting to own the rights to your work, please do not sign the CLA.
+
+## Contributing Process
+
+Start with [Prerequisites](#prerequisites) and make sure you can sign the Contributor License Agreement (CLA).
+
+### Get Buyoff Or Find Open Community Issues/Features
+
+ * Through a Github issue, talk about a feature or bug fix you like and why it should be in the Chocolatey Ansible Collection.
+ * Once you get a nod from one of the [Chocolatey Team](https://github.com/chocolatey?tab=members), you can start on the feature.
+ * Alternatively, if a feature is on the issues list with the [Up For Grabs](https://github.com/chocolatey/chocolatey-ansible/labels/Up For Grabs %2F Hacktoberfest) label, it is open for a community member (contributor) to patch. You should comment that you are signing up for it on the issue so someone else doesn't also sign up for the work.
+
+### Set Up Your Environment
+
+ * For git specific information:
+    1. Create a fork of chocolatey/chocolatey-ansible under your GitHub account. See [forks](https://help.github.com/articles/working-with-forks/) for more information.
+    1. [Clone your fork](https://help.github.com/articles/cloning-a-repository/) locally.
+    1. Open a command line and navigate to that directory.
+    1. Add the upstream fork - `git remote add upstream git@github.com:chocolatey/chocolatey-ansible.git` (or git remote add upstream https://github.com/chocolatey/chocolatey-ansible.git` if you are not using SSH).
+    1. Run `git fetch upstream`
+    1. Ensure you have user name and email set appropriately to attribute your contributions - see [Name](https://help.github.com/articles/setting-your-username-in-git/) / [Email](https://help.github.com/articles/setting-your-email-in-git/).
+    1. Ensure that the local repository has the following settings (without `--global`, these only apply to the *current* repository):
+      * `git config core.autocrlf false`
+      * `git config core.symlinks false`
+      * `git config merge.ff false`
+      * `git config merge.log true`
+      * `git config fetch.prune true`
+    1. From there you create a branch named specific to the feature.
+    1. In the branch you do work specific to the feature.
+    1. For committing the code, please see [Prepare Commits](#prepare-commits).
+    1. See [Submit Pull Request (PR)](#submit-pull-request-pr).
+ * Please also observe the following:
+    * Unless specifically requested, do not reformat the code. It makes it very difficult to see the change you've made.
+    * Do not change files that are not specific to the feature.
+    * More covered below in the [**Prepare commits**](#prepare-commits) section.
+ * Test your changes and please help us out by updating and implementing some automated tests. It is recommended that all contributors spend some time looking over the tests in the source code. You can't go wrong emulating one of the existing tests and then changing it specific to the behavior you are testing.
+    * While not an absolute requirement, automated tests will help reviewers feel comfortable about your changes, which gets your contributions accepted faster.
+ * Please do not update your branch from the master unless we ask you to. See the responding to feedback section below.
+
+### Prepare Commits
+This section serves to help you understand what makes a good commit.
+
+A commit should observe the following:
+
+ * A commit is a small logical unit that represents a change.
+ * Should include new or changed tests relevant to the changes you are making.
+ * No unnecessary whitespace. Check for whitespace with `git diff --check` and `git diff --cached --check` before commit.
+ * You can stage parts of a file for commit.
+
+A commit message should observe the following (based on ["A Note About Git Commit Messages"](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)):
+
+  * The first line of the commit message should be a short description around 50 characters in length and be prefixed with the GitHub issue it refers to with parentheses surrounding that. If the GitHub issue is #25, you should have `(#25)` prefixed to the message.
+  * If the commit is about documentation, the message should be prefixed with `(doc)`.
+  * If it is a trivial commit or one of formatting/spaces fixes, it should be prefixed with `(maint)`.
+  * After the subject, skip one line and fill out a body if the subject line is not informative enough.
+  * Sometimes you will find that even a tiny code change has a commit body that needs to be very detailed and make take more time to do than the actual change itself!
+  * The body:
+    * Should wrap at `72` characters.
+    * Explains more fully the reason(s) for the change and contrasts with previous behavior.
+    * Uses present tense. "Fix" versus "Fixed".
+
+A good example of a commit message is as follows:
+
+```
+(#7) Installation Adds All Required Folders
+
+Previously the installation script worked for the older version of
+Chocolatey. It does not work similarly for the newer version of choco
+due to location changes for the newer folders. Update the install
+script to ensure all folder paths exist.
+
+Without this change the install script will not fully install the new
+choco client properly.
+```
+
+### Submit Pull Request (PR)
+
+Prerequisites:
+
+ * You are making commits in a feature branch.
+ * All specs should be passing.
+
+Submitting PR:
+
+ * Once you feel it is ready, submit the pull request to the `chocolatey/chocolatey-ansible` repository against the `master` branch ([more information on this can be found here](https://help.github.com/articles/creating-a-pull-request)) unless specifically requested to submit it against another branch (usually `stable` in these instances).
+  * In the case of a larger change that is going to require more discussion, please submit a PR sooner. Waiting until you are ready may mean more changes than you are interested in if the changes are taking things in a direction the committers do not want to go.
+ * In the pull request, outline what you did and point to specific conversations (as in URLs) and issues that you are are resolving. This is a tremendous help for us in evaluation and acceptance.
+ * Once the pull request is in, please do not delete the branch or close the pull request (unless something is wrong with it).
+ * One of the Chocolatey Team members, or one of the committers, will evaluate it within a reasonable time period (which is to say usually within 2-4 weeks). Some things get evaluated faster or fast tracked. We are human and we have active lives outside of open source so don't fret if you haven't seen any activity on your pull request within a month or two. We don't have a Service Level Agreement (SLA) for pull requests. Just know that we will evaluate your pull request.
+
+### Respond to Feedback on Pull Request
+
+We may have feedback for you in the form of requested changes or fixes. We generally like to see that pushed against the same topic branch (it will automatically update the PR). You can also fix/squash/rebase commits and push the same topic branch with `--force` (while it is generally acceptable to do this on topic branches not in the main repository, a force push should be avoided at all costs against the main repository).
+
+If we have comments or questions when we do evaluate it and receive no response, it will probably lessen the chance of getting accepted. Eventually this means it will be closed if it is not accepted. Please know this doesn't mean we don't value your contribution, just that things go stale. If in the future you want to pick it back up, feel free to address our concerns/questions/feedback and reopen the issue/open a new PR (referencing old one).
+
+Sometimes we may need you to rebase your commit against the latest code before we can review it further. If this happens, you can do the following:
+
+ * `git fetch upstream` (upstream would be the mainstream repo or `chocolatey/chocolatey-ansible` in this case)
+ * `git checkout master`
+ * `git rebase upstream/master`
+ * `git checkout your-branch`
+ * `git rebase master`
+ * Fix any merge conflicts
+ * `git push origin your-branch` (origin would be your GitHub repo or `your-github-username/chocolatey-ansible` in this case). You may need to `git push origin your-branch --force` to get the commits pushed. This is generally acceptable with topic branches not in the mainstream repository.
+
+The only reasons a pull request should be closed and resubmitted are as follows:
+
+  * When the pull request is targeting the wrong branch (this doesn't happen as often).
+  * When there are updates made to the original by someone other than the original contributor (and the PR is not open for contributions). Then the old branch is closed with a note on the newer branch this supersedes #github_number.
+
+## Other General Information
+
+If you reformat code or hit core functionality without an approval from a person on the Chocolatey Team, it's likely that no matter how awesome it looks afterwards, it will probably not get accepted. Reformatting code makes it harder for us to evaluate exactly what was changed.
+
+If you do these things, it will make evaluation and acceptance easy. Now if you stray outside of the guidelines we have above, it doesn't mean we are going to ignore your pull request. It will just make things harder for us.  Harder for us roughly translates to a longer SLA for your pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,7 @@ The Chocolatey team has very explicit information here regarding the process for
 
 - [Are You In the Right Place?](#are-you-in-the-right-place)
   - [Reporting an Issue/Bug?](#reporting-an-issuebug)
-    - [SolutionVersion.cs](#solutionversioncs)
-  - [Package Issue?](#package-issue)
-  - [Package Request? Package Missing?](#package-request-package-missing)
   - [Submitting an Enhancement / Feature Request?](#submitting-an-enhancement--feature-request)
-    - [Submitting an Enhancement For Choco](#submitting-an-enhancement-for-choco)
 - [Contributing](#contributing)
   - [Prerequisites](#prerequisites)
     - [Definition of Trivial Contributions](#definition-of-trivial-contributions)
@@ -17,13 +13,6 @@ The Chocolatey team has very explicit information here regarding the process for
 - [Contributing Process](#contributing-process)
   - [Get Buyoff Or Find Open Community Issues/Features](#get-buyoff-or-find-open-community-issuesfeatures)
   - [Set Up Your Environment](#set-up-your-environment)
-  - [Code Format / Design](#code-format--design)
-    - [CSharp](#csharp)
-    - [PowerShell](#powershell)
-  - [Debugging / Testing](#debugging--testing)
-    - [Visual Studio](#visual-studio)
-      - [Automated Tests](#automated-tests)
-    - [Chocolatey Build](#chocolatey-build)
   - [Prepare Commits](#prepare-commits)
   - [Submit Pull Request (PR)](#submit-pull-request-pr)
   - [Respond to Feedback on Pull Request](#respond-to-feedback-on-pull-request)
@@ -39,10 +28,6 @@ Please follow this decision criteria to see if you are in the right location or 
 ### Reporting an Issue/Bug?
 
 Submitting an Issue (or a Bug)? See the **[Submitting Issues](https://github.com/chocolatey/chocolatey-ansible/tree/master/README.md#submitting-issues) section** in the README.
-
-### Package Issue?
-
-Please see [Request Package Fixes or Updates / Become a maintainer of an existing package](https://chocolatey.org/docs/package-triage-process).
 
 ### Submitting an Enhancement / Feature Request?
 
@@ -62,6 +47,7 @@ The process for contributions is roughly as follows:
  * You agree to follow the [etiquette regarding communication](https://github.com/chocolatey/choco#etiquette-regarding-communication).
 
 #### Definition of Trivial Contributions
+
 It's hard to define what is a trivial contribution. Sometimes even a 1 character change can be considered significant. Unfortunately because it can be subjective, the decision on what is trivial comes from the committers of the project and not from folks contributing to the project. It is generally safe to assume that you may be subject to signing the [CLA](https://www.clahub.com/agreements/chocolatey/choco) and be prepared to do so. Ask in advance if you are not sure and for reasons are not able to sign the [CLA](https://www.clahub.com/agreements/chocolatey/choco).
 
 What is generally considered trivial:
@@ -125,6 +111,7 @@ Start with [Prerequisites](#prerequisites) and make sure you can sign the Contri
  * Please do not update your branch from the master unless we ask you to. See the responding to feedback section below.
 
 ### Prepare Commits
+
 This section serves to help you understand what makes a good commit.
 
 A commit should observe the following:

--- a/README.md
+++ b/README.md
@@ -109,3 +109,29 @@ See [LICENSE](LICENSE) to see full text.
 
 [pipeline-link]: https://dev.azure.com/ChocolateyCI/Chocolatey-Ansible/_build/latest?definitionId=2&branchName=master
 [pipeline-badge]: https://dev.azure.com/ChocolateyCI/Chocolatey-Ansible/_apis/build/status/Chocolatey%20Collection%20CI?branchName=master
+
+## Submitting Issues
+
+Observe the following help for submitting an issue:
+
+Prerequisites:
+
+ * The issue has to do with the Chocolatey Ansible collection itself and is not a package, Chocolatey or website issue.
+ * Please check to see if your issue already exists with a quick search of the issues. Start with one relevant term and then add if you get too many results.
+ * You are not submitting an "Enhancement". Enhancements should observe [CONTRIBUTING](https://github.com/chocolatey/chocolatey-ansible/blob/master/CONTRIBUTING.md) guidelines.
+ * You are not submitting a question - questions are better served as [discussions](https://github.com/chocolatey/chocolatey-ansible/discussions).
+ * Please make sure you've read over and agree with the [etiquette regarding communication](#etiquette-regarding-communication).
+
+Submitting a ticket:
+
+ * We'll need debug and verbose output, so please run and capture the log with `-vvvv`. You can submit that with the issue or create a gist and link it.
+ * **Please note** that the verbose output may have sensitive data (passwords or api keys), so please remove those if they are there prior to submitting the issue.
+ * choco.exe logs to a file in `$env:ChocolateyInstall\log\`. You can grab the Chocolatey specific log output from there so you don't have to capture or redirect screen output. Please limit the amount included to just the command run (the log is appended to with every command).
+ * Please save the log output in a [gist](https://gist.github.com) (save the file as `log.sh`) and link to the gist from the issue. Feel free to create it as secret so it doesn't fill up against your public gists. Anyone with a direct link can still get to secret gists. If you accidentally include secret information in your gist, please delete it and create a new one (gist history can be seen by anyone) and update the link in the ticket (issue history is not retained except by email - deleting the gist ensures that no one can get to it). Using gists this way also keeps accidental secrets from being shared in the ticket in the first place as well.
+ * We'll need the entire log output from the run, so please don't limit it down to areas you feel are relevant. You may miss some important details we'll need to know. This will help expedite issue triage.
+ * It's helpful to include the version of choco, the version of the OS, and the version of PowerShell (Posh).
+ * Include screenshots and / or animated gifs whenever possible, they help show us exactly what the problem is.
+
+## Etiquette Regarding Communication
+
+If you are an open source user requesting support, please remember that most folks in the Chocolatey community are volunteers that have lives outside of open source and are not paid to ensure things work for you, so please be considerate of others' time when you are asking for things. Many of us have families that also need time as well and only have so much time to give on a daily basis. A little consideration and patience can go a long way.


### PR DESCRIPTION
Added the following:

* Issue template
* Feature request template
* Pull request template
* Security disclosure template (for consistency)
* Update README with contributing info
* CONTRIBUTING guide

Most of this was taken from the [choco](https://github.com/chocolatey/choco) repository.

@vexx32 this is in draft, however can you review in preparation for it coming out of draft?