### PR TITLE
(#57) Update CI/CD to test against multiple Ansible versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,8 +33,7 @@ stages:
     pool:
       vmImage: ubuntu-latest
     variables:
-      Ansible.Package: "ansible-core"
-      Ansible.Version: "2.11"
+      Ansible.Package: "ansible-core==2.11"
 
     steps:
     - task: Bash@3
@@ -133,14 +132,17 @@ stages:
       maxParallel: 1
       matrix:
         ansible29:
-          Ansible.Package: "ansible"
+          Ansible.Package: "ansible==2.9"
           Ansible.Version: "2.9"
         ansible210:
-          Ansible.Package: "ansible-base"
+          Ansible.Package: "ansible-base==2.10"
           Ansible.Version: "2.10"
         ansible211:
-          Ansible.Package: "ansible-core"
+          Ansible.Package: "ansible-core==2.11"
           Ansible.Version: "2.11"
+        ansible-latest:
+          Ansible.Package: "ansible-core"
+          Ansible.Version: "latest"
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -207,9 +209,7 @@ stages:
   - Test
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
   variables:
-    ansibleConfigPath: '~/ansible.cfg'
-    Ansible.Package: 'ansible-core'
-    Ansible.Version: '2.11'
+    Ansible.Package: 'ansible-core==2.11'
 
   jobs:
   - job: Publish
@@ -229,19 +229,6 @@ stages:
       inputs:
         artifact: '$(CollectionArtifactName)'
         targetPath: '$(System.DefaultWorkingDirectory)/artifacts/'
-
-#    - task: PowerShell@2
-#      displayName: 'Setup ansible.cfg'
-#      inputs:
-#        pwsh: true
-#        targetType: inline
-#        script: |
-#          $config = Get-Content -Path ./build/ansible.cfg -Raw
-#          $config = $config -replace '{{ REPLACE_GALAXY_TOKEN }}', '$(GalaxyApiKey)' -replace '{{ REPLACE_AH_TOKEN }}', '$(AHApiKey)'
-#
-#          $path = "$(ansibleConfigPath)"
-#          Write-Host "Copying Ansible publishing configuration to '$path'"
-#          $config | Set-Content -Path $path
 
     - task: PowerShell@2
       displayName: 'Publish Chocolatey Collection to Galaxy & AH'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
 # ChocoCIClient.labVMPassword: <secret>
   ChocoCIClient.ansibleUser: 'ansible-test'
 # ChocoCIClient.ansiblePassword: <secret>
-  collectionArtifactName: 'chocolatey.collection'
+  CollectionArtifactName: 'chocolatey.collection'
   Package.Version: 24.6.26
 
 trigger:
@@ -27,7 +27,63 @@ pr:
 stages:
 - stage: Build
   displayName: '[Build]'
+  jobs:
+  - job: BuildCollection
+    displayName: 'Build chocolatey.chocolatey collection'
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+      Ansible.Package: "ansible-core"
+      Ansible.Version: "2.11"
 
+    steps:
+    - task: Bash@3
+      displayName: 'Install Dependencies'
+      inputs:
+        targetType: filePath
+        filePath: ./build/dependencies.sh
+
+    - task: PowerShell@2
+      displayName: 'Build Collection'
+
+      inputs:
+        targetType: 'inline'
+        script: |
+          $version = if ("$(Build.SourceBranch)" -match '^refs/tags/(?<Tag>.+)') {
+              # Github version tags usually begin with a "v", but we just want the number
+              $matches.Tag -replace '^v'
+          }
+          else {
+              "$env:PACKAGE_VERSION-$(Get-Date -Format 'yyyyMMdd')-$(New-Guid)"
+          }
+
+          Write-Host "Building chocolatey.chocolatey with version '$version'"
+
+          Set-Location ./chocolatey
+
+          (Get-Content -Path 'galaxy.yml' -Raw) -replace '{{ REPLACE_VERSION }}', $version |
+              Set-Content -Path 'galaxy.yml'
+
+          ansible-galaxy collection build
+
+          # Locate the built tarball and expose the path & name in Azure variables
+          $CollectionTarball = Get-ChildItem -Recurse -File -Filter '*chocolatey*.tar.gz'
+
+          Write-Host "Setting artifact path to '$($CollectionTarball.FullName)'"
+          Write-Host "##vso[task.setvariable variable=ArtifactPath]$($CollectionTarball.FullName)"
+
+        errorActionPreference: 'stop'
+        failOnStderr: true
+        pwsh: true
+
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Collection Tarball Artifact'
+      inputs:
+        path: '$(ArtifactPath)'
+        artifact: '$(CollectionArtifactName)'
+
+- stage: Test
+  displayName: '[Test]'
   jobs:
   - job: CreateVM
     displayName: 'Create Windows VM'
@@ -67,7 +123,7 @@ stages:
         azurePowerShellVersion: LatestVersion
 
   - job: Tests
-    displayName: 'Create & Test Collection'
+    displayName: 'Test Collection'
     dependsOn: CreateVM
     pool:
       vmImage: ubuntu-latest
@@ -77,56 +133,27 @@ stages:
       maxParallel: 1
       matrix:
         ansible29:
-          AnsiblePackage: "ansible"
-          AnsibleVersion: "2.9"
+          Ansible.Package: "ansible"
+          Ansible.Version: "2.9"
         ansible210:
-          AnsiblePackage: "ansible-base"
-          AnsibleVersion: "2.10"
+          Ansible.Package: "ansible-base"
+          Ansible.Version: "2.10"
         ansible211:
-          AnsiblePackage: "ansible-core"
-          AnsibleVersion: "2.11"
+          Ansible.Package: "ansible-core"
+          Ansible.Version: "2.11"
 
     steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download Collection'
+      inputs:
+        artifact: '$(CollectionArtifactName)'
+        targetPath: '$(System.DefaultWorkingDirectory)/chocolatey/'
+
     - task: Bash@3
       displayName: 'Install Dependencies'
       inputs:
-        targetType: inline
-        script: |
-          sudo add-apt-repository universe
-          sudo apt update
-          sudo apt install software-properties-common
-
-          sudo apt-get update
-          sudo apt-get install python3 python3-pip python3-venv python3-dev -y
-
-          python3 -m venv ~/ansible-venv
-          source ~/ansible-venv/bin/activate
-
-          pip3 install --upgrade wheel
-          pip3 install pywinrm
-          pip3 install $(AnsiblePackage)==$(AnsibleVersion)
-
-          pip3 --version
-          ansible --version
-
-    - task: PowerShell@2
-      displayName: 'Set Package Version'
-
-      inputs:
-        targetType: 'inline'
-        script: |
-          $version = if ("$(Build.SourceBranch)" -match '^refs/tags/(?<Tag>.+)') {
-              # Github version tags usually begin with a "v", but we just want the number
-              $matches.Tag -replace '^v'
-          }
-          else {
-              "$env:PACKAGE_VERSION-$(Get-Date -Format 'yyyyMMdd')-$(New-Guid)"
-          }
-          Write-Host "##vso[task.setvariable variable=Package.Version]$version"
-
-        errorActionPreference: 'stop'
-        failOnStderr: true
-        pwsh: true
+        targetType: filePath
+        filePath: ./build/dependencies.sh
 
     - task: AzureCLI@2
       displayName: 'Run Ansible-Test for Collection'
@@ -142,13 +169,7 @@ stages:
       condition: succeededOrFailed()
       inputs:
         path: '$(System.DefaultWorkingDirectory)/testresults'
-        artifact: 'Ansible-Test Output Files'
-
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish Collection Tarball Artifact'
-      inputs:
-        path: '$(TestRun.ArtifactPath)'
-        artifact: '$(collectionArtifactName)'
+        artifact: 'Ansible-Test Output Files (ansible-$(Ansible.Version))'
 
     - task: PublishTestResults@2
       displayName: 'Publish JUnit Results'
@@ -181,10 +202,14 @@ stages:
 
 - stage: Publish
   displayName: '[Publish]'
-  dependsOn: Build
+  dependsOn:
+  - Build
+  - Test
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
   variables:
     ansibleConfigPath: '~/ansible.cfg'
+    Ansible.Package: 'ansible-core'
+    Ansible.Version: '2.11'
 
   jobs:
   - job: Publish
@@ -202,7 +227,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Tarball Artifact'
       inputs:
-        artifact: '$(collectionArtifactName)'
+        artifact: '$(CollectionArtifactName)'
         targetPath: '$(System.DefaultWorkingDirectory)/artifacts/'
 
 #    - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,13 +73,41 @@ stages:
       vmImage: ubuntu-latest
     variables:
       labVmFqdn: $[ dependencies.CreateVM.outputs['AzVmConfig.Fqdn'] ]
+    strategy:
+      maxParallel: 1
+      matrix:
+        ansible29:
+          AnsiblePackage: "ansible"
+          AnsibleVersion: "2.9"
+        ansible210:
+          AnsiblePackage: "ansible-base"
+          AnsibleVersion: "2.10"
+        ansible211:
+          AnsiblePackage: "ansible-core"
+          AnsibleVersion: "2.11"
 
     steps:
     - task: Bash@3
       displayName: 'Install Dependencies'
       inputs:
-        targetType: filePath
-        filePath: ./build/dependencies.sh
+        targetType: inline
+        script: |
+          sudo add-apt-repository universe
+          sudo apt update
+          sudo apt install software-properties-common
+
+          sudo apt-get update
+          sudo apt-get install python3 python3-pip python3-venv python3-dev -y
+
+          python3 -m venv ~/ansible-venv
+          source ~/ansible-venv/bin/activate
+
+          pip3 install --upgrade wheel
+          pip3 install pywinrm
+          pip3 install $(AnsiblePackage)==$(AnsibleVersion)
+
+          pip3 --version
+          ansible --version
 
     - task: PowerShell@2
       displayName: 'Set Package Version'

--- a/build/Invoke-CollectionTests.ps1
+++ b/build/Invoke-CollectionTests.ps1
@@ -63,7 +63,7 @@ begin {
     )
     $CleanupCommands = @(
         "cp -r ./tests/output/ $OutputPath"
-        "rm -r $OutputPath/.tmp"
+        "rm -r $OutputPath/.tmp 2> /dev/null"
     )
 #endregion
 

--- a/build/Invoke-CollectionTests.ps1
+++ b/build/Invoke-CollectionTests.ps1
@@ -21,27 +21,42 @@ param(
 begin {
     Push-Location
 
-    $InventoryFile = if ($IsCIBuild) { 'ci-inventory.winrm' } else { 'vagrant-inventory.winrm' }
-    $Sudo = if ($IsCIBuild) { [string]::Empty } else { "sudo " }
-
-    $OutputPath = if ($IsCIBuild) {
+    $InventoryFile, $Sudo, $OutputPath = if ($IsCIBuild) {
+        'ci-inventory.winrm'
+        [string]::Empty
         Join-Path -Path $env:SYSTEM_DEFAULTWORKINGDIRECTORY -ChildPath 'testresults/'
     }
     else {
+        'vagrant-inventory.winrm'
+        "sudo "
         '~/.testresults/'
     }
 
+#region Bash Commands
+    # All command strings in this region must be valid Bash command lines; the lines following this region join
+    # the provided commands into a single command string.
     $ImportVenv = 'source ~/ansible-venv/bin/activate'
     $SetCollectionLocation = 'cd ~/.ansible/collections/ansible_collections/chocolatey/chocolatey'
     $SetupCommands = @(
         $ImportVenv
         'cd ./chocolatey'
-        'ansible-galaxy collection build'
+
+        # Skip building collection in CI; this will have been done already by a previous CI step.
+        if (-not $IsCIBuild) {
+            'ansible-galaxy collection build'
+        }
+
         'ansible-galaxy collection install *.tar.gz'
     )
-    $RunTests = @(
+    $TestCommands = @(
         $SetCollectionLocation
         $ImportVenv
+
+        if ($IsCIBuild) {
+            # Copy the CI inventory file into the collection for testing
+            "cp ~/$InventoryFile ./tests/integration/$InventoryFile"
+        }
+
         "${Sudo}ansible-test windows-integration -vvvv --inventory $InventoryFile --requirements --continue-on-error"
         "${Sudo}ansible-test sanity -vvvvv --requirements"
         "${Sudo}ansible-test coverage xml -vvvvv --requirements"
@@ -50,13 +65,14 @@ begin {
         "cp -r ./tests/output/ $OutputPath"
         "rm -r $OutputPath/.tmp"
     )
-    
+#endregion
+
     # Join these with && so if the setup fails, the tests don't try to run
     $Commands = @(
         $SetupCommands
         # Join these with ; so if an individual step fails, continue to run so we can get as many results as possible
         @(
-            $RunTests
+            $TestCommands
             $CleanupCommands
         ) -join ' ; '
     ) -join ' && '
@@ -82,15 +98,9 @@ process {
                 "ansible_become_method=runas"
             )
 
-            $Inventory | Set-Content -Path './chocolatey/tests/integration/ci-inventory.winrm'
-            (Get-Content -Path './chocolatey/galaxy.yml' -Raw) -replace '{{ REPLACE_VERSION }}', $env:PACKAGE_VERSION |
-                Set-Content -Path './chocolatey/galaxy.yml'
-            bash -c $Commands
+            $Inventory | Set-Content -Path "~/$InventoryFile" -Force
 
-            # Locate the built tarball and expose the path & name in Azure variables
-            $CollectionTarball = Get-ChildItem -Path './chocolatey' -Recurse -File -Filter '*chocolatey*.tar.gz'
-            Write-Host "##vso[task.setvariable variable=ArtifactPath;isOutput=true]$($CollectionTarball.FullName)"
-            Write-Host "##vso[task.setvariable variable=ArtifactName;isOutput=true]$($CollectionTarball.Name)"
+            bash -c $Commands
         }
         else {
             Set-Location -Path $PSScriptRoot
@@ -98,6 +108,10 @@ process {
 
             if (-not $?) {
                 throw "An error has occurred; please refer to the Vagrant log for details."
+            }
+
+            if (-not $env:PACKAGE_VERSION) {
+                $env:PACKAGE_VERSION = '24.6.26'
             }
 
             vagrant ssh choco_ansible_server --command "sed -i ./chocolatey/galaxy.yml 's/{{ REPLACE_VERSION }}/$env:PACKAGE_VERSION/g'"

--- a/build/Invoke-CollectionTests.ps1
+++ b/build/Invoke-CollectionTests.ps1
@@ -53,11 +53,14 @@ begin {
         $ImportVenv
 
         if ($IsCIBuild) {
-            # Copy the CI inventory file into the collection for testing
-            "cp ~/$InventoryFile ./tests/integration/$InventoryFile"
+            # Move the CI inventory file into the collection for testing
+            "mv -f ~/$InventoryFile ./tests/integration/inventory.winrm"
+        }
+        else {
+            "mv -f ./tests/integration/$InventoryFile ./tests/integration/inventory.winrm"
         }
 
-        "${Sudo}ansible-test windows-integration -vvvv --inventory $InventoryFile --requirements --continue-on-error"
+        "${Sudo}ansible-test windows-integration -vvv --requirements --continue-on-error"
         "${Sudo}ansible-test sanity -vvvvv --requirements"
         "${Sudo}ansible-test coverage xml -vvvvv --requirements"
     )
@@ -96,7 +99,7 @@ process {
                 "ansible_winrm_transport=ntlm"
                 "ansible_winrm_server_cert_validation=ignore"
                 "ansible_become_method=runas"
-            )
+            ) -join "`n"
 
             $Inventory | Set-Content -Path "~/$InventoryFile" -Force
 

--- a/build/Vagrantfile
+++ b/build/Vagrantfile
@@ -26,6 +26,10 @@ Vagrant.configure("2") do |config|
 
     server.vm.provision "install dependencies", type: "shell" do |shell|
       shell.path = "./dependencies.sh"
+      shell.env = {
+        "ANSIBLE_PACKAGE" => "ansible-core",
+        "ANSIBLE_VERSION" => "2.11"
+      }
     end
 
     server.vm.provision "copy collection files", type: "file" do |file|

--- a/build/Vagrantfile
+++ b/build/Vagrantfile
@@ -27,8 +27,7 @@ Vagrant.configure("2") do |config|
     server.vm.provision "install dependencies", type: "shell" do |shell|
       shell.path = "./dependencies.sh"
       shell.env = {
-        "ANSIBLE_PACKAGE" => "ansible-core",
-        "ANSIBLE_VERSION" => "2.11"
+        "ANSIBLE_PACKAGE" => "ansible-core"
       }
     end
 

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -12,7 +12,7 @@ source ~/ansible-venv/bin/activate
 
 pip3 install --upgrade wheel
 pip3 install pywinrm
-pip3 install $ANSIBLE_PACKAGE==$ANSIBLE_VERSION
+pip3 install $ANSIBLE_PACKAGE
 
 pip3 --version
 ansible --version

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -2,21 +2,17 @@
 
 sudo add-apt-repository universe
 sudo apt update
+sudo apt install software-properties-common
+
 sudo apt-get update
-
 sudo apt-get install python3 python3-pip python3-venv python3-dev -y
-sudo apt install python2
-curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-sudo python2 get-pip.py
-
-
 
 python3 -m venv ~/ansible-venv
 source ~/ansible-venv/bin/activate
 
-pip3 --version
 pip3 install --upgrade wheel
-pip3 install ansible pywinrm
+pip3 install pywinrm
+pip3 install $ANSIBLE_PACKAGE==$ANSIBLE_VERSION
 
-pip2 --version
-pip2 install --upgrade wheel
+pip3 --version
+ansible --version

--- a/chocolatey/plugins/modules/win_chocolatey_facts.py
+++ b/chocolatey/plugins/modules/win_chocolatey_facts.py
@@ -121,7 +121,7 @@ ansible_facts:
               description: The source, can be a folder/file or an url
               returned: always
               type: str
-              sample: https://chocolatey.org/api/v2/
+              sample: https://community.chocolatey.org/api/v2/
             source_username:
               description: Username used to access authenticated feeds
               returned: always

--- a/chocolatey/tests/integration/targets/win_chocolatey_facts/tasks/main.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey_facts/tasks/main.yml
@@ -55,7 +55,7 @@
     - ansible_chocolatey.sources[0].disabled == False
     - ansible_chocolatey.sources[0].name == 'chocolatey'
     - ansible_chocolatey.sources[0].priority == 0
-    - ansible_chocolatey.sources[0].source == 'https://chocolatey.org/api/v2/'
+    - ansible_chocolatey.sources[0].source == 'https://community.chocolatey.org/api/v2/'
     - ansible_chocolatey.sources[0].source_username == None
     - ansible_chocolatey.sources[1].admin_only == True
     - ansible_chocolatey.sources[1].allow_self_service == True

--- a/chocolatey/tests/integration/targets/win_chocolatey_source/tasks/main.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey_source/tasks/main.yml
@@ -22,7 +22,7 @@
   - name: ensure original Chocolatey source is re-added
     win_chocolatey_source:
       name: chocolatey
-      source: https://chocolatey.org/api/v2/
+      source: https://community.chocolatey.org/api/v2/
       state: present
 
   - name: remove test Chocolatey source

--- a/chocolatey/tests/integration/targets/win_chocolatey_source/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey_source/tasks/tests.yml
@@ -2,7 +2,7 @@
 - name: create source (check mode)
   win_chocolatey_source:
     name: chocolatey
-    source: https://chocolatey.org/api/v2/
+    source: https://community.chocolatey.org/api/v2/
     state: present
   register: create_check
   check_mode: yes
@@ -20,7 +20,7 @@
 - name: create source
   win_chocolatey_source:
     name: chocolatey
-    source: https://chocolatey.org/api/v2/
+    source: https://community.chocolatey.org/api/v2/
     state: present
   register: create
 
@@ -34,7 +34,7 @@
     - create is changed
     - create_actual.sources|length == 1
     - create_actual.sources[0].name == 'chocolatey'
-    - create_actual.sources[0].source == 'https://chocolatey.org/api/v2/'
+    - create_actual.sources[0].source == 'https://community.chocolatey.org/api/v2/'
     - create_actual.sources[0].disabled == False
     - create_actual.sources[0].source_username == None
     - create_actual.sources[0].priority == 0
@@ -46,7 +46,7 @@
 - name: create source (idempotent)
   win_chocolatey_source:
     name: chocolatey
-    source: https://chocolatey.org/api/v2/
+    source: https://community.chocolatey.org/api/v2/
     state: present
   register: create_again
 


### PR DESCRIPTION
## Description

Update the CI/CD to ensure we're testing against:

- Ansible 2.9
- Ansible-Base 2.10
- Ansible-Core 2.11
- Ansible-Core 2.12.x (latest version)

## Related Issues

- Closes #57
- Closes #64

## Motivation

We need to be testing on current and a few older versions of Ansible to remain certified, so updating this build pipeline will keep things going there, and give us a better idea of when things break, if anything happens to break only on specific Ansible versions.

Thanks to using an azp matrix strategy, we can add any future versions as needed as well.

I am also resolving #64 here in a separate commit as it was getting tripped up over those tests.