### PR TITLE
Add state: upgrade as more intuitive alias for state: latest

### DIFF
--- a/build/Invoke-CollectionTests.ps1
+++ b/build/Invoke-CollectionTests.ps1
@@ -35,11 +35,11 @@ begin {
 #region Bash Commands
     # All command strings in this region must be valid Bash command lines; the lines following this region join
     # the provided commands into a single command string.
-    $ImportVenv = 'source ~/ansible-venv/bin/activate'
+    $ImportVenv = '. ~/ansible-venv/bin/activate'
     $SetCollectionLocation = 'cd ~/.ansible/collections/ansible_collections/chocolatey/chocolatey'
     $SetupCommands = @(
         $ImportVenv
-        'cd ./chocolatey'
+        'cd chocolatey'
 
         # Skip building collection in CI; this will have been done already by a previous CI step.
         if (-not $IsCIBuild) {
@@ -57,7 +57,7 @@ begin {
             "mv -f ~/$InventoryFile ./tests/integration/inventory.winrm"
         }
         else {
-            "mv -f ./tests/integration/$InventoryFile ./tests/integration/inventory.winrm"
+            "mv -f tests/integration/$InventoryFile tests/integration/inventory.winrm"
         }
 
         "${Sudo}ansible-test windows-integration -vvv --requirements --continue-on-error"
@@ -117,7 +117,7 @@ process {
                 $env:PACKAGE_VERSION = '24.6.26'
             }
 
-            vagrant ssh choco_ansible_server --command "sed -i ./chocolatey/galaxy.yml 's/{{ REPLACE_VERSION }}/$env:PACKAGE_VERSION/g'"
+            vagrant ssh choco_ansible_server --command "sed -i 's/{{ REPLACE_VERSION }}/$env:PACKAGE_VERSION/g' ./chocolatey/galaxy.yml"
             vagrant ssh choco_ansible_server --command $Commands
             $Result = [PSCustomObject]@{
                 Success  = $?

--- a/build/Vagrantfile
+++ b/build/Vagrantfile
@@ -18,14 +18,14 @@ Vagrant.configure("2") do |config|
   # boxes at https://vagrantcloud.com/search.
 
   config.vm.define :choco_ansible_server do |server|
-    server.vm.box = "bento/ubuntu-19.10"
-    server.vm.box_version = "201910.31.0"
+    server.vm.box = "bento/ubuntu-20.04"
+    server.vm.box_version = "202112.19.0"
 
     server.vm.hostname = "ansible-server"
     server.vm.network :private_network, ip: "10.0.0.10"
 
     server.vm.provision "install dependencies", type: "shell" do |shell|
-      shell.path = "./dependencies.sh"
+      shell.path = "./vagrant-dependencies.sh"
       shell.env = {
         "ANSIBLE_PACKAGE" => "ansible-core"
       }

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -1,18 +1,17 @@
 #!/bin/sh
 
 sudo add-apt-repository universe
-sudo apt update
-sudo apt install software-properties-common
-
 sudo apt-get update
+sudo apt-get install software-properties-common
 sudo apt-get install python3 python3-pip python3-venv python3-dev -y
 
 python3 -m venv ~/ansible-venv
 source ~/ansible-venv/bin/activate
 
 pip3 install --upgrade wheel
+pip3 install 'pyOpenSSL<22.0.0'
 pip3 install pywinrm
-pip3 install $ANSIBLE_PACKAGE
+pip3 install "$ANSIBLE_PACKAGE"
 
 pip3 --version
 ansible --version

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -5,6 +5,17 @@ sudo apt-get update
 sudo apt-get install software-properties-common
 sudo apt-get install python3 python3-pip python3-venv python3-dev -y
 
+# Ensure pwsh is installed (Ansible requires this for some sanity tests)
+sudo apt-get install -y wget apt-transport-https software-properties-common
+# Download the Microsoft repository GPG keys
+wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
+# Register the Microsoft repository GPG keys
+sudo dpkg -i packages-microsoft-prod.deb
+# Update the list of packages after we added packages.microsoft.com
+sudo apt-get update
+# Install PowerShell
+sudo apt-get install -y powershell
+
 python3 -m venv ~/ansible-venv
 source ~/ansible-venv/bin/activate
 

--- a/build/vagrant-dependencies.sh
+++ b/build/vagrant-dependencies.sh
@@ -6,14 +6,6 @@ sudo apt-get install software-properties-common
 sudo apt-get install python3 python3-pip python3-venv python3-dev -y
 sudo pip install virtualenv
 
-virtualenv /home/vagrant/ansible-venv
-. /home/vagrant/ansible-venv/bin/activate
-
-pip3 install --upgrade wheel
-pip3 install 'pyOpenSSL<22.0.0'
-pip3 install pywinrm
-pip3 install "$ANSIBLE_PACKAGE"
-
 # Ensure pwsh is installed (Ansible requires this for some sanity tests)
 sudo apt-get install -y wget apt-transport-https software-properties-common
 # Download the Microsoft repository GPG keys
@@ -24,6 +16,15 @@ sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get update
 # Install PowerShell
 sudo apt-get install -y powershell
+
+virtualenv /home/vagrant/ansible-venv
+. /home/vagrant/ansible-venv/bin/activate
+
+pip3 install --upgrade wheel
+pip3 install 'pyOpenSSL<22.0.0'
+pip3 install pywinrm
+pip3 install "$ANSIBLE_PACKAGE"
+
 
 pip3 --version
 ansible --version

--- a/build/vagrant-dependencies.sh
+++ b/build/vagrant-dependencies.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+sudo add-apt-repository universe
+sudo apt-get update
+sudo apt-get install software-properties-common
+sudo apt-get install python3 python3-pip python3-venv python3-dev -y
+sudo pip install virtualenv
+
+virtualenv /home/vagrant/ansible-venv
+. /home/vagrant/ansible-venv/bin/activate
+
+pip3 install --upgrade wheel
+pip3 install 'pyOpenSSL<22.0.0'
+pip3 install pywinrm
+pip3 install "$ANSIBLE_PACKAGE"
+
+# Ensure pwsh is installed (Ansible requires this for some sanity tests)
+sudo apt-get install -y wget apt-transport-https software-properties-common
+# Download the Microsoft repository GPG keys
+wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
+# Register the Microsoft repository GPG keys
+sudo dpkg -i packages-microsoft-prod.deb
+# Update the list of packages after we added packages.microsoft.com
+sudo apt-get update
+# Install PowerShell
+sudo apt-get install -y powershell
+
+pip3 --version
+ansible --version

--- a/chocolatey/plugins/modules/win_chocolatey.py
+++ b/chocolatey/plugins/modules/win_chocolatey.py
@@ -197,11 +197,11 @@ options:
     - When C(present), will ensure the package is installed.
     - When C(downgrade), will allow Chocolatey to downgrade a package if
       I(version) is older than the installed version.
-    - When C(latest), will ensure the package is installed to the latest
+    - When C(latest) or C(upgrade), will ensure the package is installed to the latest
       available version.
     - When C(reinstalled), will uninstall and reinstall the package.
     type: str
-    choices: [ absent, downgrade, latest, present, reinstalled ]
+    choices: [ absent, downgrade, upgrade, latest, present, reinstalled ]
     default: present
   timeout:
     description:
@@ -226,8 +226,11 @@ options:
     - Specific version of the package to be installed.
     - When I(state) is set to C(absent), will uninstall the specific version
       otherwise all versions of that package will be removed.
-    - If a different version of package is installed, I(state) must be C(latest)
-      or I(force) set to C(yes) to install the desired version.
+    - When I(state) is set to C(present) and the package is already installed
+      at a version that does not match, this task fails.
+    - If a different version of package is already installed, I(state) must be
+      C(latest), C(upgrade), or C(downgrade), or I(force) must be set to C(yes) to install
+      the desired version.
     - Provide as a string (e.g. C('6.1')), otherwise it is considered to be
       a floating-point number and depending on the locale could become C(6,1),
       which will cause a failure.

--- a/chocolatey/plugins/modules/win_chocolatey_source.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_source.ps1
@@ -17,11 +17,11 @@ $spec = @{
         allow_self_service   = @{ type = "bool" }
         bypass_proxy         = @{ type = "bool" }
         certificate          = @{ type = "str" }
-        certificate_password = @{ type = "str" }
+        certificate_password = @{ type = "str"; no_log = $true }
         priority             = @{ type = "int" }
         source               = @{ type = "str" }
         source_username      = @{ type = "str" }
-        source_password      = @{ type = "str" }
+        source_password      = @{ type = "str"; no_log = $true }
         update_password      = @{ type = "str"; default = "always"; choices = "always", "on_create" }
     }
     supports_check_mode = $true

--- a/chocolatey/plugins/modules/win_chocolatey_source.py
+++ b/chocolatey/plugins/modules/win_chocolatey_source.py
@@ -45,10 +45,12 @@ options:
     description:
     - The password for I(certificate) if required.
     - Requires Chocolatey >= 0.9.10.
+    type: str
   name:
     description:
     - The name of the source to configure.
     required: yes
+    type: str
   priority:
     description:
     - The priority order of this source compared to other sources, lower is
@@ -63,13 +65,16 @@ options:
     - The file/folder/url of the source.
     - Required when I(state) is C(present) or C(disabled) and the source does
       not already exist.
+    type: str
   source_username:
     description:
     - The username used to access I(source).
+    type: str
   source_password:
     description:
     - The password for I(source_username).
     - Required if I(source_username) is set.
+    type: str
   state:
     description:
     - When C(absent), will remove the source.
@@ -80,6 +85,7 @@ options:
     - disabled
     - present
     default: present
+    type: str
   update_password:
     description:
     - When C(always), the module will always set the password and report a
@@ -90,6 +96,7 @@ options:
     - always
     - on_create
     default: always
+    type: str
 seealso:
 - module: win_chocolatey
 - module: win_chocolatey_config

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -278,7 +278,7 @@
     state: present
     version: 0.1.0
   register: fail_multiple_versions
-  failed_when: fail_multiple_versions.msg != "Chocolatey package '" + test_choco_package1 + "' is already installed with version(s) '0.0.1' but was expecting '0.1.0'. Either change the expected version, set state=latest, set allow_multiple=yes, or set force=yes to continue"
+  failed_when: fail_multiple_versions.msg != "Chocolatey package '" + test_choco_package1 + "' is already installed with version(s) '0.0.1' but was expecting '0.1.0'. Either change the expected version, set state=latest or state=upgrade, set allow_multiple=yes, or set force=yes to continue"
 
 - name: force the upgrade of an existing version
   win_chocolatey:
@@ -408,6 +408,28 @@
     that:
     - upgrade_package is changed
     - upgrade_package_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]
+
+- name: downgrade package again
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: downgrade
+    version: '0.0.1'
+
+- name: upgrade package with state=upgrade
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: upgrade
+  register: upgrade_package_with_state_upgrade
+
+- name: get result of upgrade package with state=upgrade
+  win_command: choco.exe list --local-only --limit-output --exact {{ test_choco_package1|quote }}
+  register: actual_after_upgrade_with_state_upgrade
+
+- name: assert upgrade package with state=upgrade
+  assert:
+    that:
+    - upgrade_package_with_state_upgrade is changed
+    - actual_after_upgrade_with_state_upgrade.stdout_lines == [test_choco_package1 + "|0.1.0"]
 
 - name: upgrade package (idempotent)
   win_chocolatey:


### PR DESCRIPTION
## Description Of Changes

- Added `upgrade` state value as a valid option for `win_chocolatey`.
- Updated tests to also test this new state value.
- Updated py docs to make it a bit clearer why things can fail with `state: present` if a specific version is targeted

## Motivation and Context

See #59 -- our documentation and the commands necessary do not always make it clear that `state: latest` is required for certain usage patterns, especially when combined with `version:` to specify a target version.

This PR adds a `state: upgrade` as a more intuitive alias to the existing `state: latest` to better mirror the also existing `state: downgrade` and be a little clearer.

The py documentation has been updated a little to explain a little more of why playbooks that target a specific version with `state: present` may fail instead of upgrading/downgrading the package if it already exists.

## Testing

Added tests for `state: upgrade` similar to tests we have for `state: latest`

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Resolves #59

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
