### PR TITLE
(#15) Allow additional choco args to be passed manually

### DIFF
--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -20,10 +20,10 @@ $spec = @{
         allow_multiple = @{ type = "bool"; default = $false }
         allow_prerelease = @{ type = "bool"; default = $false }
         architecture = @{ type = "str"; default = "default"; choices = "default", "x86" }
+        choco_args = @{ type = "list"; elements = "str"; aliases = "licensed_args" }
         force = @{ type = "bool"; default = $false }
         ignore_checksums = @{ type = "bool"; default = $false }
         ignore_dependencies = @{ type = "bool"; default = $false }
-        remove_dependencies = @{ type = "bool"; default = $false }
         install_args = @{ type = "str" }
         name = @{ type = "list"; elements = "str"; required = $true }
         override_args = @{ type = "bool"; default = $false }
@@ -32,6 +32,7 @@ $spec = @{
         proxy_url = @{ type = "str" }
         proxy_username = @{ type = "str" }
         proxy_password = @{ type = "str"; no_log = $true }
+        remove_dependencies = @{ type = "bool"; default = $false }
         skip_scripts = @{  type = "bool"; default = $false }
         source = @{ type = "str" }
         source_username = @{ type = "str" }
@@ -49,10 +50,10 @@ $allow_empty_checksums = $module.Params.allow_empty_checksums
 $allow_multiple = $module.Params.allow_multiple
 $allow_prerelease = $module.Params.allow_prerelease
 $architecture = $module.Params.architecture
+$choco_args = $module.Params.choco_args
 $force = $module.Params.force
 $ignore_checksums = $module.Params.ignore_checksums
 $ignore_dependencies = $module.Params.ignore_dependencies
-$remove_dependencies = $module.Params.remove_dependencies
 $install_args = $module.Params.install_args
 $name = $module.Params.name
 $override_args = $module.Params.override_args
@@ -61,6 +62,7 @@ $pinned = $module.Params.pinned
 $proxy_url = $module.Params.proxy_url
 $proxy_username = $module.Params.proxy_username
 $proxy_password = $module.Params.proxy_password
+$remove_dependencies = $module.Params.remove_dependencies
 $skip_scripts = $module.Params.skip_scripts
 $source = $module.Params.source
 $source_username = $module.Params.source_username
@@ -103,6 +105,7 @@ Function Get-InstallChocolateyArguments {
         [bool]$allow_multiple,
         [bool]$allow_prerelease,
         [String]$architecture,
+        [string[]] $choco_args,
         [bool]$force,
         [bool]$ignore_dependencies,
         [String]$install_args,
@@ -191,6 +194,9 @@ Function Get-InstallChocolateyArguments {
     if ($version) {
         $arguments.Add("--version") > $null
         $arguments.Add($version) > $null
+    }
+    if ($choco_args) {
+        $arguments.AddRange($choco_args)
     }
 
     return ,$arguments
@@ -509,6 +515,7 @@ Function Update-ChocolateyPackage {
         [bool]$allow_multiple,
         [bool]$allow_prerelease,
         [String]$architecture,
+        [string[]] $choco_args,
         [bool]$force,
         [bool]$ignore_checksums,
         [bool]$ignore_dependencies,
@@ -535,6 +542,7 @@ Function Update-ChocolateyPackage {
         allow_multiple = $allow_multiple
         allow_prerelease = $allow_prerelease
         architecture = $architecture
+        choco_args = $choco_args
         force = $force
         ignore_checksums = $ignore_checksums
         ignore_dependencies = $ignore_dependencies
@@ -586,6 +594,7 @@ Function Install-ChocolateyPackage {
         [bool]$allow_multiple,
         [bool]$allow_prerelease,
         [String]$architecture,
+        [string[]] $choco_args,
         [bool]$force,
         [bool]$ignore_checksums,
         [bool]$ignore_dependencies,
@@ -611,6 +620,7 @@ Function Install-ChocolateyPackage {
         allow_multiple = $allow_multiple
         allow_prerelease = $allow_prerelease
         architecture = $architecture
+        choco_args = $choco_args
         force = $force
         ignore_checksums = $ignore_checksums
         ignore_dependencies = $ignore_dependencies
@@ -811,6 +821,7 @@ if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
         allow_multiple = $allow_multiple
         allow_prerelease = $allow_prerelease
         architecture = $architecture
+        choco_args = $choco_args
         force = $force
         ignore_checksums = $ignore_checksums
         ignore_dependencies = $ignore_dependencies

--- a/chocolatey/plugins/modules/win_chocolatey.py
+++ b/chocolatey/plugins/modules/win_chocolatey.py
@@ -121,6 +121,20 @@ options:
     type: str
     version_added: '0.2.1'
     aliases: [ params ]
+  choco_args:
+    description:
+    - Additional parameters to pass to choco.exe
+    - These may be any additional parameters to pass through directly to
+      Chocolatey, in addition to the arguments already specified via other
+      parameters.
+    - This may be used to pass licensed options to Chocolatey, for example
+      C(--package-parameters-sensitive) or C(--install-directory).
+    - Passing licensed options may result in them being ignored or causing
+      errors if the targeted node is unlicensed or missing the
+      chocolatey.extension package.
+    type: list
+    version_added: '1.2.0'
+    aliases: [ licensed_args ]
   pinned:
     description:
     - Whether to pin the Chocolatey package or not.
@@ -384,6 +398,15 @@ EXAMPLES = r'''
     name: notepadplusplus
     pinned: no
     state: present
+
+- name: install a package with options that require licensed edition
+  win_chocolatey:
+    name: foo
+    state: present
+    choco_args:
+    - --skip-download-cache
+    - --package-parameters-sensitive
+    - '/Password=SecretPassword'
 '''
 
 RETURN = r'''

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -260,6 +260,53 @@
     - (install_params_info.stdout|from_json).source == "normal"
     - (install_params_info.stdout|from_json).timeout == "2700000"
 
+- name: reinstall package with manually specified params
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: reinstalled
+    choco_args:
+    - --install-args
+    - '/install_arg 1 /install_arg 2'
+    - --override-arguments
+    - --package-parameters
+    - '/param1 /param2:value'
+    - --allow-empty-checksums
+    - --x86
+    - --force
+    - --ignore-checksums
+    - --version
+    - '0.0.1'
+    - --proxy
+    - 'http://proxyhost'
+
+  register: install_manual_params
+
+- name: get result of install package with manually specified params
+  win_command: choco.exe list --local-only --limit-output --exact {{ test_choco_package1|quote }}
+  register: install_manual_params_actual
+
+- name: get info of install package with manually specified params
+  win_shell: Get-Content -Path '{{ test_choco_path }}\{{ test_choco_package1 }}-0.0.1.txt'
+  register: install_manual_params_info
+
+- name: assert install package with manually specified params
+  assert:
+    that:
+    - install_manual_params is changed
+    - install_manual_params_actual.stdout_lines == [test_choco_package1 + "|0.0.1"]
+    - (install_manual_params_info.stdout|from_json).allow_empty_checksums == True
+    - (install_manual_params_info.stdout|from_json).force == True
+    - (install_manual_params_info.stdout|from_json).force_x86 == True
+    - (install_manual_params_info.stdout|from_json).ignore_checksums == True
+    - (install_manual_params_info.stdout|from_json).install_args == "/install_arg 1 /install_arg 2"
+    - (install_manual_params_info.stdout|from_json).override_args == True
+    - (install_manual_params_info.stdout|from_json).package_params.keys()|count == 2
+    - (install_manual_params_info.stdout|from_json).package_params.param1 == True
+    - (install_manual_params_info.stdout|from_json).package_params.param2 == "value"
+    - (install_manual_params_info.stdout|from_json).proxy_url == "http://proxyhost"
+    - (install_manual_params_info.stdout|from_json).source == "normal"
+    - (install_manual_params_info.stdout|from_json).timeout == "2700000"
+
 - name: install package with version (idempotent)
   win_chocolatey:
     name: '{{ test_choco_package1 }}'


### PR DESCRIPTION
## Description Of Changes

- Added `choco_args` option (aliased also to `licensed_args`) that allows users to manually pass in a list of args to be passed directly to choco itself.
- Updated py docs
- Added a test for the new option

## Motivation and Context

This allows users to specify arguments that are not explicity supported by the collection, for example any options that require the chocolatey licensed extension to be installed.

This also gives us a workaround / stop-gap for any additional arguments in open source Chocolatey in future, allowing users to specify them manually until the collection is updated to include those options.

## Testing

Added a CI test that replicates one of the existing installer tests, with the arguments being manually passed in via the new options, instead of using the typical installation options.

NOTE: We do not explicitly test licensed options here, as we don't run our CI with a licensed edition of Chocolatey. However, any additional licensed args will function the same way that passing args manually would work.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #15

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
