### PR TITLE
(#61) Add requirements.txt file and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 | :----------------------------------------------: |
 | [![Build Status][pipeline-badge]][pipeline-link] |
 
-This repo hosts the `chocolatey.chocolatey` Ansible Collection.
+The `chocolatey.chocolatey` Ansible Collection includes the modules required to configure Chocolatey, as well as manage packages on Windows using Chocolatey.
 
-The collection includes the modules required to configure Chocolatey, as well as manage packages on Windows using Chocolatey.
+## Ansible version compatibility
+
+This collection has been tested against the following Ansible versions:
+**>=2.9, 2.10, 2.11, 2.12**
 
 ## Installation and Usage
 
@@ -29,7 +32,7 @@ This collection provides the following modules you can use in your own roles:
 
 | Name                          | Description                               |
 |-------------------------------|-------------------------------------------|
-|`win_chocolatey`               | Manage packages using chocolatey          |  
+|`win_chocolatey`               | Manage packages using chocolatey          |
 |`win_chocolatey_config`        | Manage Chocolatey config settings         |
 |`win_chocolatey_facts`         | Create a facts collection for Chocolatey  |
 |`win_chocolatey_feature`       | Manage Chocolatey features                |

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -22,8 +22,6 @@ source ~/ansible-venv/bin/activate
 pip3 install --upgrade pip
 pip3 install --upgrade wheel
 pip3 install packaging
-pip3 install 'pyOpenSSL<22.0.0'
-pip3 install pywinrm
 pip3 install "$ANSIBLE_PACKAGE"
 
 ansible-galaxy collection install ansible.windows

--- a/build/vagrant-dependencies.sh
+++ b/build/vagrant-dependencies.sh
@@ -23,8 +23,6 @@ virtualenv /home/vagrant/ansible-venv
 pip3 install --upgrade pip
 pip3 install wheel
 pip3 install packaging
-pip3 install 'pyOpenSSL<22.0.0'
-pip3 install pywinrm
 pip3 install "$ANSIBLE_PACKAGE"
 
 ansible-galaxy collection install ansible.windows

--- a/chocolatey/requirements.txt
+++ b/chocolatey/requirements.txt
@@ -1,0 +1,2 @@
+pyOpenSSL<22.0.0
+pywinrm


### PR DESCRIPTION
## Description Of Changes

Added `requirements.txt` file for our Python dependencies that help handle the remoting layer to Windows.
Removed the explicit install commands for these dependencies 

## Motivation and Context

It's a good idea to declare the dependencies of the collection so they're more discoverable and can be automatically taken care of, and it's one of the requirements of the collection being/remaining certified (if I understand the documentation correctly).

## Testing

1. Ran the test script locally, things seemed to install just fine and run without issue, even without explicitly installing. (Note: still seeing the issue locally with loading certain ansible.windows modules from #71, so I'm reopening that issue presently)
2. Running in CI to double check. Looking at the CI logs for the start of the test runs show Ansible downloading `pywinrm` and other related dependencies so it's safe to say that the requirements.txt is doing its job, ensuring that the dependencies are also installed when the collection is installed. (Previously we were installing those manually during the install dependencies step; this has been reduced to only install Ansible and some build-time-only dependencies.)

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

#61

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.

Task: CU-ENGTASKS-1154