### PR TITLE
(#78) Fix module linting issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,6 +140,9 @@ stages:
         ansible211:
           Ansible.Package: "ansible-core==2.11"
           Ansible.Version: "2.11"
+        ansible212:
+          Ansible.Package: "ansible-core==2.12"
+          Ansible.Version: "2.12"
         ansible-latest:
           Ansible.Package: "ansible-core"
           Ansible.Version: "latest"

--- a/chocolatey/plugins/module_utils/Common.psm1
+++ b/chocolatey/plugins/module_utils/Common.psm1
@@ -153,8 +153,9 @@ function ConvertFrom-Stdout {
         [hashtable]
         $CommandResult
     )
-
-    $CommandResult.stdout.Trim() -split "\r?\n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    process {
+        $CommandResult.stdout.Trim() -split "\r?\n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    }
 }
 
 function Set-TaskResultChanged {

--- a/chocolatey/plugins/module_utils/Common.psm1
+++ b/chocolatey/plugins/module_utils/Common.psm1
@@ -136,7 +136,7 @@ function Assert-TaskFailed {
     }
 }
 
-function Get-StdoutLines {
+function ConvertFrom-Stdout {
     <#
         .SYNOPSIS
         Trims and splits the stdout from the given result so that individual
@@ -177,7 +177,7 @@ function Set-TaskResultChanged {
 Export-ModuleMember -Function @(
     'Get-ChocolateyCommand'
     'Get-AnsibleModule'
-    'Get-StdoutLines'
+    'ConvertFrom-Stdout'
     'Set-ActiveModule'
     'Set-TaskResultChanged'
     'Assert-TaskFailed'

--- a/chocolatey/plugins/module_utils/Features.psm1
+++ b/chocolatey/plugins/module_utils/Features.psm1
@@ -38,7 +38,7 @@ function Get-ChocolateyFeature {
     # either `$true` (enabled), or `$false` (disabled)
     $features = @{}
     $result |
-        Get-StdoutLines |
+        ConvertFrom-Stdout |
         Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
         ForEach-Object {
             $name, $state, $null = $_ -split "\|"

--- a/chocolatey/plugins/module_utils/Packages.psm1
+++ b/chocolatey/plugins/module_utils/Packages.psm1
@@ -34,7 +34,7 @@ function Get-ChocolateyOutdated {
     }
 
     $result |
-        Get-StdoutLines |
+        ConvertFrom-Stdout |
         ForEach-Object {
             # Sanity check in case additional output is added in the future.
             if ($_.Contains('|')) {
@@ -90,7 +90,7 @@ function Get-ChocolateyPackage {
     }
 
     $result |
-        Get-StdoutLines |
+        ConvertFrom-Stdout |
         ForEach-Object {
             # Sanity check in case additional output is added in the future.
             if ($_.Contains('|')) {
@@ -158,7 +158,7 @@ function Get-ChocolateyPackageVersion {
     }
 }
 
-function Get-CommonChocolateyArguments {
+function Get-CommonChocolateyArgument {
     <#
         .SYNOPSIS
         Retrieves a set of common Chocolatey arguments.
@@ -199,7 +199,7 @@ function Get-CommonChocolateyArguments {
     }
 }
 
-function Get-InstallChocolateyArguments {
+function ConvertTo-ChocolateyArgument {
     <#
         .SYNOPSIS
         Translates parameters into commonly used Chocolatey command line arguments.
@@ -322,7 +322,7 @@ function Get-InstallChocolateyArguments {
     "--fail-on-unfound"
 
     # Include common arguments for installing/updating a Chocolatey package
-    Get-CommonChocolateyArguments
+    Get-CommonChocolateyArgument
 
     if ($AllowDowngrade) { "--allow-downgrade" }
     if ($AllowEmptyChecksums) { "--allow-empty-checksums" }
@@ -383,7 +383,7 @@ function Get-ChocolateyPin {
     $pins = @{}
 
     $result |
-        Get-StdoutLines |
+        ConvertFrom-Stdout |
         ForEach-Object {
             $package, $version, $null = $_.Split('|')
 
@@ -445,7 +445,7 @@ function Set-ChocolateyPin {
             "--version", $Version
         }
 
-        Get-CommonChocolateyArguments
+        Get-CommonChocolateyArgument
     )
 
     $command = Argv-ToString -Arguments $arguments
@@ -601,7 +601,7 @@ function Update-ChocolateyPackage {
         $ChocoCommand.Path
         "upgrade"
         $Package
-        Get-InstallChocolateyArguments @commonParams
+        ConvertTo-ChocolateyArgument @commonParams
     )
 
     $command = Argv-ToString -Arguments $arguments
@@ -771,7 +771,7 @@ function Install-ChocolateyPackage {
         $ChocoCommand.Path
         "install"
         $Package
-        Get-InstallChocolateyArguments @commonParams
+        ConvertTo-ChocolateyArgument @commonParams
     )
 
     $command = Argv-ToString -Arguments $arguments
@@ -859,7 +859,7 @@ function Uninstall-ChocolateyPackage {
         $ChocoCommand.Path
         "uninstall"
         $Package
-        Get-CommonChocolateyArguments
+        Get-CommonChocolateyArgument
 
         if ($Version) {
             "--version", $Version
@@ -1112,12 +1112,12 @@ function Install-Chocolatey {
 }
 
 Export-ModuleMember -Function @(
+    'ConvertTo-ChocolateyArgument'
     'Get-ChocolateyOutdated'
     'Get-ChocolateyPackage'
     'Get-ChocolateyPackageVersion'
     'Get-ChocolateyPin'
-    'Get-CommonChocolateyArguments'
-    'Get-InstallChocolateyArguments'
+    'Get-CommonChocolateyArgument'
     'Set-ChocolateyPin'
     'Install-Chocolatey'
     'Install-ChocolateyPackage'

--- a/chocolatey/plugins/module_utils/Packages.psm1
+++ b/chocolatey/plugins/module_utils/Packages.psm1
@@ -1096,12 +1096,12 @@ function Install-Chocolatey {
 
         $Module.Warn("Chocolatey was older than v0.10.5 so it will be upgraded during this task run.")
         $params = @{
-            ChocoCommand   = $chocoCommand
-            Packages       = @("chocolatey")
-            ProxyUrl       = $ProxyUrl
-            ProxyUsername  = $ProxyUsername
-            ProxyPassword  = $ProxyPassword
-            Source         = $Source
+            ChocoCommand = $chocoCommand
+            Packages = @("chocolatey")
+            ProxyUrl = $ProxyUrl
+            ProxyUsername = $ProxyUsername
+            ProxyPassword = $ProxyPassword
+            Source = $Source
             SourceUsername = $SourceUsername
             SourcePassword = $SourcePassword
         }

--- a/chocolatey/plugins/module_utils/Packages.psm1
+++ b/chocolatey/plugins/module_utils/Packages.psm1
@@ -1083,14 +1083,21 @@ function Install-Chocolatey {
         $actualVersion = [Version]$actualVersion
     }
     catch {
-        $Module.Warn("Failed to parse Chocolatey version '$actualVersion' for checking module requirements, module may not work correctly: $($_.Exception.Message)")
+        $warning = @(
+            "Failed to parse Chocolatey version '$actualVersion' for checking module requirements."
+            "Module may not work correctly: $($_.Exception.Message)"
+        ) -join ' '
+        $Module.Warn($warning)
         $actualVersion = $null
     }
 
     if ($null -ne $actualVersion -and $actualVersion -lt [Version]"0.10.5") {
         if ($Module.CheckMode) {
             $Module.Result.skipped = $true
-            $Module.Result.msg = "Skipped check mode run on win_chocolatey as choco.exe is too old, a real run would have upgraded the executable. Actual: '$actualVersion', Minimum Version: '0.10.5'"
+            $Module.Result.msg = @(
+                "Skipped check mode run on win_chocolatey as choco.exe is too old, a real run would have upgraded the executable."
+                "Actual: '$actualVersion', Minimum Version: '0.10.5'"
+            ) -join ' '
             $Module.ExitJson()
         }
 

--- a/chocolatey/plugins/module_utils/Sources.psm1
+++ b/chocolatey/plugins/module_utils/Sources.psm1
@@ -44,8 +44,8 @@ function Get-ChocolateySource {
 
     foreach ($sourceNode in $configXml.chocolatey.sources.GetEnumerator()) {
         $sourceInfo = @{
-            name     = $sourceNode.id
-            source   = $sourceNode.value
+            name = $sourceNode.id
+            source = $sourceNode.value
             disabled = [System.Convert]::ToBoolean($sourceNode.disabled)
         }
 
@@ -210,15 +210,15 @@ function New-ChocolateySource {
     }
 
     @{
-        name               = $Name
-        source             = $Source
-        disabled           = $false
-        source_username    = $Username
-        priority           = $Priority
-        certificate        = $Certificate
-        bypass_proxy       = $BypassProxy.IsPresent
+        name = $Name
+        source = $Source
+        disabled = $false
+        source_username = $Username
+        priority = $Priority
+        certificate = $Certificate
+        bypass_proxy = $BypassProxy.IsPresent
         allow_self_service = $AllowSelfService.IsPresent
-        admin_only         = $AdminOnly.IsPresent
+        admin_only = $AdminOnly.IsPresent
     }
 }
 

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -189,7 +189,11 @@ if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
 
             if ($packageVersions.Count -gt 0) {
                 if (-not $packageVersions.Contains($version) -and -not $allow_multiple) {
-                    $message = "Chocolatey package '$package' is already installed with version(s) '$($packageVersions -join "', '")' but was expecting '$version'. Either change the expected version, set state=latest or state=upgrade, set allow_multiple=yes, or set force=yes to continue"
+                    $message = @(
+                        "Chocolatey package '$package' is already installed with version(s) '$($packageVersions -join "', '")'"
+                        "but was expecting '$version'. Either change the expected version, set state=latest or state=upgrade,"
+                        "set allow_multiple=yes, or set force=yes to continue"
+                    ) -join ' '
                     Assert-TaskFailed -Message $message
                 }
                 elseif ($version -notin $packageVersions -and $allow_multiple) {

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -13,40 +13,53 @@
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Common
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Packages
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseConsistentWhitespace',
+    '',
+    Justification = 'Relax whitespace rule for better readability in module spec',
+    Scope = 'function',
+    # Apply suppression specifically to module spec
+    Target = 'Get-ModuleSpec')]
+param()
+
 # As of chocolatey 0.9.10, non-zero success exit codes can be returned
 # See https://github.com/chocolatey/choco/issues/512#issuecomment-214284461
 $script:successExitCodes = (0, 1605, 1614, 1641, 3010)
 
-$spec = @{
-    options             = @{
-        allow_empty_checksums = @{ type = "bool"; default = $false }
-        allow_multiple        = @{ type = "bool"; default = $false }
-        allow_prerelease      = @{ type = "bool"; default = $false }
-        architecture          = @{ type = "str"; default = "default"; choices = "default", "x86" }
-        choco_args            = @{ type = "list"; elements = "str"; aliases = "licensed_args" }
-        force                 = @{ type = "bool"; default = $false }
-        ignore_checksums      = @{ type = "bool"; default = $false }
-        ignore_dependencies   = @{ type = "bool"; default = $false }
-        install_args          = @{ type = "str" }
-        name                  = @{ type = "list"; elements = "str"; required = $true }
-        override_args         = @{ type = "bool"; default = $false }
-        package_params        = @{ type = "str"; aliases = @("params") }
-        pinned                = @{ type = "bool" }
-        proxy_url             = @{ type = "str" }
-        proxy_username        = @{ type = "str" }
-        proxy_password        = @{ type = "str"; no_log = $true }
-        remove_dependencies   = @{ type = "bool"; default = $false }
-        skip_scripts          = @{ type = "bool"; default = $false }
-        source                = @{ type = "str" }
-        source_username       = @{ type = "str" }
-        source_password       = @{ type = "str"; no_log = $true }
-        state                 = @{ type = "str"; default = "present"; choices = "absent", "downgrade", "upgrade", "latest", "present", "reinstalled" }
-        timeout               = @{ type = "int"; default = 2700; aliases = @("execution_timeout") }
-        validate_certs        = @{ type = "bool"; default = $true }
-        version               = @{ type = "str" }
+function Get-ModuleSpec {
+    @{
+        options             = @{
+            allow_empty_checksums = @{ type = "bool"; default = $false }
+            allow_multiple        = @{ type = "bool"; default = $false }
+            allow_prerelease      = @{ type = "bool"; default = $false }
+            architecture          = @{ type = "str"; default = "default"; choices = "default", "x86" }
+            choco_args            = @{ type = "list"; elements = "str"; aliases = "licensed_args" }
+            force                 = @{ type = "bool"; default = $false }
+            ignore_checksums      = @{ type = "bool"; default = $false }
+            ignore_dependencies   = @{ type = "bool"; default = $false }
+            install_args          = @{ type = "str" }
+            name                  = @{ type = "list"; elements = "str"; required = $true }
+            override_args         = @{ type = "bool"; default = $false }
+            package_params        = @{ type = "str"; aliases = @("params") }
+            pinned                = @{ type = "bool" }
+            proxy_url             = @{ type = "str" }
+            proxy_username        = @{ type = "str" }
+            proxy_password        = @{ type = "str"; no_log = $true }
+            remove_dependencies   = @{ type = "bool"; default = $false }
+            skip_scripts          = @{ type = "bool"; default = $false }
+            source                = @{ type = "str" }
+            source_username       = @{ type = "str" }
+            source_password       = @{ type = "str"; no_log = $true }
+            state                 = @{ type = "str"; default = "present"; choices = "absent", "downgrade", "upgrade", "latest", "present", "reinstalled" }
+            timeout               = @{ type = "int"; default = 2700; aliases = @("execution_timeout") }
+            validate_certs        = @{ type = "bool"; default = $true }
+            version               = @{ type = "str" }
+        }
+        supports_check_mode = $true
     }
-    supports_check_mode = $true
 }
+
+$spec = Get-ModuleSpec
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 Set-ActiveModule $module
@@ -131,15 +144,15 @@ if ($state -in "absent", "reinstalled") {
             # even if a specific version is targeted.
             $useAllowMultiple = $packageInfo.$package.Count -gt 1
             $uninstallParams = @{
-                ChocoCommand       = $chocoCommand
-                Package            = $package
-                Force              = $force
-                PackageParams      = $package_params
-                SkipScripts        = $skip_scripts
+                ChocoCommand = $chocoCommand
+                Package = $package
+                Force = $force
+                PackageParams = $package_params
+                SkipScripts = $skip_scripts
                 RemoveDependencies = $remove_dependencies
-                Timeout            = $timeout
-                Version            = $version
-                AllowMultiple      = $useAllowMultiple
+                Timeout = $timeout
+                Version = $version
+                AllowMultiple = $useAllowMultiple
             }
             Uninstall-ChocolateyPackage @uninstallParams
         }

--- a/chocolatey/plugins/modules/win_chocolatey.py
+++ b/chocolatey/plugins/modules/win_chocolatey.py
@@ -28,7 +28,7 @@ options:
     description:
     - Allow empty checksums to be used for downloaded resource from non-secure
       locations.
-    - Use M(win_chocolatey_feature) with the name C(allowEmptyChecksums) to
+    - Use M(chocolatey.chocolatey.win_chocolatey_feature) with the name C(allowEmptyChecksums) to
       control this option globally.
     type: bool
     default: no
@@ -73,7 +73,7 @@ options:
   ignore_checksums:
     description:
     - Ignore the checksums provided by the package.
-    - Use M(win_chocolatey_feature) with the name C(checksumFiles) to control
+    - Use M(chocolatey.chocolatey.win_chocolatey_feature) with the name C(checksumFiles) to control
       this option globally.
     type: bool
     default: no
@@ -150,7 +150,7 @@ options:
   proxy_url:
     description:
     - Proxy URL used to install chocolatey and the package.
-    - Use M(win_chocolatey_config) with the name C(proxy) to control this
+    - Use M(chocolatey.chocolatey.win_chocolatey_config) with the name C(proxy) to control this
       option globally.
     type: str
     version_added: '0.2.4'
@@ -159,7 +159,7 @@ options:
     - Proxy username used to install Chocolatey and the package.
     - Before Ansible 2.7, users with double quote characters C(") would need to
       be escaped with C(\) beforehand. This is no longer necessary.
-    - Use M(win_chocolatey_config) with the name C(proxyUser) to control this
+    - Use M(chocolatey.chocolatey.win_chocolatey_config) with the name C(proxyUser) to control this
       option globally.
     type: str
     version_added: '0.2.4'
@@ -168,7 +168,7 @@ options:
     - Proxy password used to install Chocolatey and the package.
     - This value is exposed as a command argument and any privileged account
       can see this value when the module is running Chocolatey, define the
-      password on the global config level with M(win_chocolatey_config) with
+      password on the global config level with M(chocolatey.chocolatey.win_chocolatey_config) with
       name C(proxyPassword) to avoid this.
     type: str
     version_added: '0.2.4'
@@ -182,10 +182,10 @@ options:
   source:
     description:
     - Specify the source to retrieve the package from.
-    - Use M(win_chocolatey_source) to manage global sources.
+    - Use M(chocolatey.chocolatey.win_chocolatey_source) to manage global sources.
     - This value can either be the URL to a Chocolatey feed, a path to a folder
       containing C(.nupkg) packages or the name of a source defined by
-      M(win_chocolatey_source).
+      M(chocolatey.chocolatey.win_chocolatey_source).
     - This value is also used when Chocolatey is not installed as the location
       of the install.ps1 script and only supports URLs for this case.
     type: str
@@ -194,7 +194,7 @@ options:
     - A username to use with I(source) when accessing a feed that requires
       authentication.
     - It is recommended you define the credentials on a source with
-      M(win_chocolatey_source) instead of passing it per task.
+      M(chocolatey.chocolatey.win_chocolatey_source) instead of passing it per task.
     type: str
     version_added: '0.2.7'
   source_password:
@@ -202,7 +202,7 @@ options:
     - The password for I(source_username).
     - This value is exposed as a command argument and any privileged account
       can see this value when the module is running Chocolatey, define the
-      credentials with a source with M(win_chocolatey_source) to avoid this.
+      credentials with a source with M(chocolatey.chocolatey.win_chocolatey_source) to avoid this.
     type: str
     version_added: '0.2.7'
   state:
@@ -264,19 +264,19 @@ notes:
   Even if you are connecting as local Administrator, using C(become) to
   become Administrator will give you an interactive user logon, see examples
   below.
-- If C(become) is unavailable, use M(win_hotfix) to install hotfixes instead
-  of M(win_chocolatey) as M(win_hotfix) avoids using C(wusa.exe) which cannot
+- If C(become) is unavailable, use M(community.windows.win_hotfix) to install hotfixes instead
+  of M(chocolatey.chocolatey.win_chocolatey) as M(community.windows.win_hotfix) avoids using C(wusa.exe) which cannot
   be run without C(become).
 seealso:
-- module: win_chocolatey_config
-- module: win_chocolatey_facts
-- module: win_chocolatey_feature
-- module: win_chocolatey_source
-- module: win_feature
-- module: win_hotfix
+- module: chocolatey.chocolatey.win_chocolatey_config
+- module: chocolatey.chocolatey.win_chocolatey_facts
+- module: chocolatey.chocolatey.win_chocolatey_feature
+- module: chocolatey.chocolatey.win_chocolatey_source
+- module: community.windows.win_feature
+- module: community.windows.win_hotfix
   description: Use when C(become) is unavailable, to avoid using C(wusa.exe).
-- module: win_package
-- module: win_updates
+- module: community.windows.win_package
+- module: community.windows.win_updates
 - name: Chocolatey website
   description: More information about the Chocolatey tool.
   link: http://chocolatey.org/

--- a/chocolatey/plugins/modules/win_chocolatey_config.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_config.ps1
@@ -12,24 +12,36 @@
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Common
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Config
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseConsistentWhitespace',
+    '',
+    Justification = 'Relax whitespace rule for better readability in module spec',
+    Scope = 'function',
+    # Apply suppression specifically to module spec
+    Target = 'Get-ModuleSpec')]
+param()
+
 $ErrorActionPreference = "Stop"
 
 # Documentation: https://docs.ansible.com/ansible/2.10/dev_guide/developing_modules_general_windows.html#windows-new-module-development
-
-$spec = @{
-    options             = @{
-        name  = @{ type = "str"; required = $true }
-        state = @{ type = "str"; default = "present"; choices = "absent", "present" }
-        value = @{ type = "str" }
+function Get-ModuleSpec {
+    @{
+        options             = @{
+            name  = @{ type = "str"; required = $true }
+            state = @{ type = "str"; default = "present"; choices = "absent", "present" }
+            value = @{ type = "str" }
+        }
+        required_if         = @(
+            # Explicit prefix `,` required, Ansible wants a list of lists for `required_if`
+            # Read as:
+            # ,@( [if] property, [is] value, [require] other_properties, $true_if_only_one_other_is_required ) -- last option is not mandatory
+            , @( 'state', 'present', @( 'value' ) )
+        )
+        supports_check_mode = $true
     }
-    required_if         = @(
-        # Explicit prefix `,` required, Ansible wants a list of lists for `required_if`
-        # Read as:
-        # ,@( [if] property, [is] value, [require] other_properties, $true_if_only_one_other_is_required ) -- last option is not mandatory
-        , @( 'state', 'present', @( 'value' ) )
-    )
-    supports_check_mode = $true
 }
+
+$spec = Get-ModuleSpec
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 Set-ActiveModule $module

--- a/chocolatey/plugins/modules/win_chocolatey_facts.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_facts.ps1
@@ -17,14 +17,27 @@
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Features
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Packages
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseConsistentWhitespace',
+    '',
+    Justification = 'Relax whitespace rule for better readability in module spec',
+    Scope = 'function',
+    # Apply suppression specifically to module spec
+    Target = 'Get-ModuleSpec')]
+param()
+
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2.0
 
 # Documentation: https://docs.ansible.com/ansible/2.10/dev_guide/developing_modules_general_windows.html#windows-new-module-development
-$spec = @{
-    options = @{}
-    supports_check_mode = $true
+function Get-ModuleSpec {
+    @{
+        options             = @{}
+        supports_check_mode = $true
+    }
 }
+
+$spec = Get-ModuleSpec
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 Set-ActiveModule $module
@@ -33,9 +46,9 @@ $chocoCommand = Get-ChocolateyCommand
 
 $module.Result.ansible_facts = @{
     ansible_chocolatey = @{
-        config   = @{}
-        feature  = @{}
-        sources  = @()
+        config = @{}
+        feature = @{}
+        sources = @()
         packages = @()
         outdated = @()
     }

--- a/chocolatey/plugins/modules/win_chocolatey_facts.py
+++ b/chocolatey/plugins/modules/win_chocolatey_facts.py
@@ -19,12 +19,12 @@ short_description: Create a facts collection for Chocolatey
 description:
 - This module shows information from Chocolatey, such as installed packages, outdated packages, configuration, feature and sources.
 notes:
-- Chocolatey must be installed beforehand, use M(win_chocolatey) to do this.
+- Chocolatey must be installed beforehand, use M(chocolatey.chocolatey.win_chocolatey) to do this.
 seealso:
-- module: win_chocolatey
-- module: win_chocolatey_config
-- module: win_chocolatey_feature
-- module: win_chocolatey_source
+- module: chocolatey.chocolatey.win_chocolatey
+- module: chocolatey.chocolatey.win_chocolatey_config
+- module: chocolatey.chocolatey.win_chocolatey_feature
+- module: chocolatey.chocolatey.win_chocolatey_source
 author:
 - Simon Bärlocher (@sbaerlocher)
 - ITIGO AG (@itigoag)

--- a/chocolatey/plugins/modules/win_chocolatey_feature.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_feature.ps1
@@ -12,16 +12,29 @@
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Common
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Features
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseConsistentWhitespace',
+    '',
+    Justification = 'Relax whitespace rule for better readability in module spec',
+    Scope = 'function',
+    # Apply suppression specifically to module spec
+    Target = 'Get-ModuleSpec')]
+param()
+
 $ErrorActionPreference = "Stop"
 
 # Documentation: https://docs.ansible.com/ansible/2.10/dev_guide/developing_modules_general_windows.html#windows-new-module-development
-$spec = @{
-    options             = @{
-        name  = @{ type = "str"; required = $true }
-        state = @{ type = "str"; default = "enabled"; choices = "disabled", "enabled" }
+function Get-ModuleSpec {
+    @{
+        options             = @{
+            name  = @{ type = "str"; required = $true }
+            state = @{ type = "str"; default = "enabled"; choices = "disabled", "enabled" }
+        }
+        supports_check_mode = $true
     }
-    supports_check_mode = $true
 }
+
+$spec = Get-ModuleSpec
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 Set-ActiveModule $module

--- a/chocolatey/plugins/modules/win_chocolatey_source.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey_source.ps1
@@ -12,32 +12,45 @@
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Common
 #AnsibleRequires -PowerShell ansible_collections.chocolatey.chocolatey.plugins.module_utils.Sources
 
-# Documentation: https://docs.ansible.com/ansible/2.10/dev_guide/developing_modules_general_windows.html#windows-new-module-development
-$spec = @{
-    options             = @{
-        name                 = @{ type = "str"; required = $true }
-        state                = @{ type = "str"; default = "present"; choices = "absent", "disabled", "present" }
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseConsistentWhitespace',
+    '',
+    Justification = 'Relax whitespace rule for better readability in module spec',
+    Scope = 'function',
+    # Apply suppression specifically to module spec
+    Target = 'Get-ModuleSpec')]
+param()
 
-        admin_only           = @{ type = "bool" }
-        allow_self_service   = @{ type = "bool" }
-        bypass_proxy         = @{ type = "bool" }
-        certificate          = @{ type = "str" }
-        certificate_password = @{ type = "str"; no_log = $true }
-        priority             = @{ type = "int" }
-        source               = @{ type = "str" }
-        source_username      = @{ type = "str" }
-        source_password      = @{ type = "str"; no_log = $true }
-        update_password      = @{ type = "str"; default = "always"; choices = "always", "on_create" }
-    }
-    supports_check_mode = $true
-    required_together   = @(
-        # Explicit `,` prefix required to prevent the array unrolling, Ansible requires nested arrays here.
-        , @( 'source_username', 'source_password' )
-    )
-    required_by         = @{
-        'certificate_password' = 'certificate'
+# Documentation: https://docs.ansible.com/ansible/2.10/dev_guide/developing_modules_general_windows.html#windows-new-module-development
+function Get-ModuleSpec {
+    @{
+        options             = @{
+            name                 = @{ type = "str"; required = $true }
+            state                = @{ type = "str"; default = "present"; choices = "absent", "disabled", "present" }
+
+            admin_only           = @{ type = "bool" }
+            allow_self_service   = @{ type = "bool" }
+            bypass_proxy         = @{ type = "bool" }
+            certificate          = @{ type = "str" }
+            certificate_password = @{ type = "str"; no_log = $true }
+            priority             = @{ type = "int" }
+            source               = @{ type = "str" }
+            source_username      = @{ type = "str" }
+            source_password      = @{ type = "str"; no_log = $true }
+            update_password      = @{ type = "str"; default = "always"; choices = "always", "on_create" }
+        }
+        supports_check_mode = $true
+        required_together   = @(
+            # Explicit `,` prefix required to prevent the array unrolling, Ansible requires nested arrays here.
+            , @( 'source_username', 'source_password' )
+        )
+        required_by         = @{
+            'certificate_password' = 'certificate'
+        }
     }
 }
+
+$spec = Get-ModuleSpec
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 Set-ActiveModule $module

--- a/chocolatey/tests/integration/targets/setup_win_chocolatey/files/tools/chocolateyinstall.ps1
+++ b/chocolatey/tests/integration/targets/setup_win_chocolatey/files/tools/chocolateyinstall.ps1
@@ -7,34 +7,45 @@ $source = "--- SOURCE ---"  # used by the test to determine which source it was 
 
 if ($env:ChocolateyAllowEmptyChecksums) {
     $allow_empty_checksums = $true
-} else {
+}
+else {
     $allow_empty_checksums = $false
 }
+
 if ($env:ChocolateyIgnoreChecksums) {
     $ignore_checksums = $true
-} else {
+}
+else {
     $ignore_checksums = $false
 }
+
 if ($env:ChocolateyForce) {
     $force = $true
-} else {
+}
+else {
     $force = $false
 }
+
 if ($env:ChocolateyForceX86) {
     $force_x86 = $true
-} else {
+}
+else {
     $force_x86 = $false
 }
+
 if ($env:ChocolateyInstallOverride) {
     $override_args = $true
-} else {
+}
+else {
     $override_args = $false
 }
+
 #$process_env = Get-EnvironmentVariableNames -Scope Process
 #$env_vars = @{}
 #foreach ($name in $process_env) {
 #  $env_vars.$name = Get-EnvironmentVariable -Name $name -Scope Process
 #}
+
 $timeout = $env:chocolateyResponseTimeout
 
 $package_info = @{

--- a/chocolatey/tests/integration/targets/win_chocolatey_source/library/choco_source.ps1
+++ b/chocolatey/tests/integration/targets/win_chocolatey_source/library/choco_source.ps1
@@ -50,15 +50,15 @@ foreach ($xml_source in $choco_config.chocolatey.sources.GetEnumerator()) {
     }
 
     $source_info = @{
-        name               = $xml_source.id
-        source             = $xml_source.value
-        disabled           = [System.Convert]::ToBoolean($xml_source.disabled)
-        source_username    = $source_username
-        priority           = $priority
-        certificate        = $certificate
-        bypass_proxy       = $bypass_proxy
+        name = $xml_source.id
+        source = $xml_source.value
+        disabled = [System.Convert]::ToBoolean($xml_source.disabled)
+        source_username = $source_username
+        priority = $priority
+        certificate = $certificate
+        bypass_proxy = $bypass_proxy
         allow_self_service = $allow_self_service
-        admin_only         = $admin_only
+        admin_only = $admin_only
     }
     $result.sources.Add($source_info)
 }


### PR DESCRIPTION
## Description Of Changes

- Renamed some internal PowerShell commands to conform to PSSA style requirements
- Added missing `process` block for a pipeline command
- Went through and removed unnecessary whitespace.
  - Note: for module spec hashtables which tend to be complex, opted to instead suppress the PSSA rule there as it can be more readable to pad spacing a bit to better indicate which items belong to which hashtable in the nested structure(s).
- Split some long error messages into separate lines
- Added FQCN (fully qualified collection name... I think?) to all `M()` module references used in the modules' documentation and `seealso` sections.
- Added ansible-core 2.12 to test targets since latest is now 2.13

## Motivation and Context

`ansible-core` 2.13 has improved the linting a good bit, and we need to conform a little better to the recommended styles to keep things consistent where possible.

## Testing

1. CI testing (will look at adding a specific 2.13 target if we need to)
2. Testing locally with `ansible-test sanity --requirements` and/or `ansible-test sanity --docker`

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Linting fixes
* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue


Fixes #78

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.