### PR TITLE
(#84) Update testing Vagrantfile to install PowerShell

### DIFF
--- a/testing-chocolatey/Vagrantfile
+++ b/testing-chocolatey/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.require_version ">= 1.6.0"
 Vagrant.configure("2") do |config|
 
   config.vm.define :choco_ansible_server do |server|
-    server.vm.box = "roboxes/ubuntu2010"
+    server.vm.box = "roboxes/ubuntu2204"
 
     server.vm.hostname = "ansible-server"
     server.vm.network :private_network, ip: "10.0.0.10"
@@ -28,8 +28,17 @@ Vagrant.configure("2") do |config|
 
     server.vm.provision "shell" do |sh|
       sh.inline = <<-SH
+        # Install python venv
         sudo apt-get update
         sudo apt-get install python3-venv -y
+
+        # Install PowerShell
+        sudo apt-get update
+        sudo apt-get install -y wget apt-transport-https software-properties-common
+        wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
+        sudo dpkg -i packages-microsoft-prod.deb
+        sudo apt-get update
+        sudo apt-get install -y powershell
 
         python3 -m venv ~/ansible
         source ~/ansible/bin/activate


### PR DESCRIPTION
## Description Of Changes

Update the Vagrantfile in the `testing-chocolatey` directory to install PowerShell so that sanity tests can be run in it.

## Motivation and Context

Need the ability to test all aspects of the collection.

## Testing

1. Copy a build from Azure DevOps into the `testing-chocolatey` directory
2. In the `testing-chocolatey` directory ran `vagrant up`
3. Run `vagrant ssh choco_ansible_server`
4. Run `source ~/ansible/bin/activate`
5. Run `ansible-galaxy collection install /vagrant/chocolatey-chocolatey.tar.gz`
6. Run `ansible-test sanity --requirements` (Note: `--requirements` is needed of PSScriptAnalyzer is not available)
7. The tests pass

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [x] Test infrastructure update

## Related Issue

Fixes #84 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.