### PR TITLE
(#83) Fix issues with Linux host in local testing

### DIFF
--- a/chocolatey/tests/integration/vagrant-inventory.winrm
+++ b/chocolatey/tests/integration/vagrant-inventory.winrm
@@ -6,5 +6,6 @@ ansible_user=vagrant
 ansible_password=vagrant
 ansible_connection=winrm
 ansible_port=5985
-ansible_winrm_transport=ntlm
+ansible_winrm_transport=credssp
+ansible_winrm_server_cert_validation=ignore
 ansible_become_method=runas

--- a/testing-chocolatey/Vagrantfile
+++ b/testing-chocolatey/Vagrantfile
@@ -64,8 +64,8 @@ Vagrant.configure("2") do |config|
   config.winrm.basic_auth_only = true
 
   config.vm.define :choco_win_client do |client|
-    # client.vm.box = "StefanScherer/windows_10"                  # Starts 'Windows Update' when Vagrant is still running resulting in connection errors. 
-    client.vm.box = "gusztavvargadr/windows-server"               # Windows 2022
+    # client.vm.box = "StefanScherer/windows_10"                  # Starts 'Windows Update' when Vagrant is still running resulting in connection errors.
+    client.vm.box = "StefanScherer/windows_2022"               # Windows 2022
     client.vm.communicator = "winrm"
     client.vm.guest = :windows
     client.vm.hostname = "win-client"
@@ -97,7 +97,7 @@ Vagrant.configure("2") do |config|
         & ([scriptblock]::Create($installScript))
         # Enable CredSSP/https in WinRM
         Enable-WSManCredSSP -Role Server -Force
-        
+
         # Install Chocolatey
         $installScript = Invoke-WebRequest -Uri "https://community.chocolatey.org/install.ps1" -UseBasicParsing
         & ([scriptblock]::Create($installScript))

--- a/testing-chocolatey/Vagrantfile
+++ b/testing-chocolatey/Vagrantfile
@@ -64,9 +64,8 @@ Vagrant.configure("2") do |config|
   config.winrm.basic_auth_only = true
 
   config.vm.define :choco_win_client do |client|
-    # client.vm.box = "StefanScherer/windows_10"                  # Installs Windows updates when Vagrant is still running resulting in connection errors. 
+    # client.vm.box = "StefanScherer/windows_10"                  # Starts 'Windows Update' when Vagrant is still running resulting in connection errors. 
     client.vm.box = "gusztavvargadr/windows-server"               # Windows 2022
-    # client.vm.box = "jborean93-VAGRANTSLASH-WindowsServer2016"  # Connection failure after 'vagrant up' 
     client.vm.communicator = "winrm"
     client.vm.guest = :windows
     client.vm.hostname = "win-client"

--- a/testing-chocolatey/Vagrantfile
+++ b/testing-chocolatey/Vagrantfile
@@ -55,8 +55,18 @@ Vagrant.configure("2") do |config|
 
   end
 
+  # Needed when running on Fedora 36.
+  config.winrm.transport = :plaintext
+  config.winrm.max_tries = 300
+  config.winrm.retry_delay = 2
+  config.winrm.username = 'vagrant'
+  config.winrm.password = 'vagrant'
+  config.winrm.basic_auth_only = true
+
   config.vm.define :choco_win_client do |client|
-    client.vm.box = "StefanScherer/windows_10"
+    # client.vm.box = "StefanScherer/windows_10"                  # Installs Windows updates when Vagrant is still running resulting in connection errors. 
+    client.vm.box = "gusztavvargadr/windows-server"               # Windows 2022
+    # client.vm.box = "jborean93-VAGRANTSLASH-WindowsServer2016"  # Connection failure after 'vagrant up' 
     client.vm.communicator = "winrm"
     client.vm.guest = :windows
     client.vm.hostname = "win-client"
@@ -66,14 +76,11 @@ Vagrant.configure("2") do |config|
     client.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true, host_ip: "127.0.0.1"
     client.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true, host_ip: "127.0.0.1"
 
-    client.winrm.username = "vagrant"
-    client.winrm.password = "vagrant"
-
     client.vm.provider :virtualbox do |vbox|
       vbox.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
       vbox.gui = false
       vbox.customize ["modifyvm", :id, "--vram", 32]
-      vbox.customize ["modifyvm", :id, "--memory", "1024"]
+      vbox.customize ["modifyvm", :id, "--memory", "2048"]
       vbox.customize ["modifyvm", :id, "--audio", "none"]
       vbox.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
       vbox.customize ["modifyvm", :id, "--draganddrop", "hosttoguest"]
@@ -86,6 +93,12 @@ Vagrant.configure("2") do |config|
 
     client.vm.provision "shell" do |ps|
       ps.inline = <<-PS1
+        # Configure WinRM for Ansible
+        $installScript = Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1" -UseBasicParsing
+        & ([scriptblock]::Create($installScript))
+        # Enable CredSSP/https in WinRM
+        Enable-WSManCredSSP -Role Server -Force
+        
         # Install Chocolatey
         $installScript = Invoke-WebRequest -Uri "https://community.chocolatey.org/install.ps1" -UseBasicParsing
         & ([scriptblock]::Create($installScript))

--- a/testing-chocolatey/local-testing.md
+++ b/testing-chocolatey/local-testing.md
@@ -1,10 +1,11 @@
 # Beta-Testing Chocolatey with the Ansible Collection
 
-- [Prerequisites](#prerequisites)
-- [Getting Started](#getting-started)
-  - [Vagrant](#vagrant)
-  - [Generic](#generic)
-- [Running `ansible-test`](#running-ansible-test)
+- [Beta-Testing Chocolatey with the Ansible Collection](#beta-testing-chocolatey-with-the-ansible-collection)
+  - [Prerequisites](#prerequisites)
+  - [Getting Started](#getting-started)
+    - [Vagrant](#vagrant)
+    - [Generic](#generic)
+  - [Running `ansible-test`](#running-ansible-test)
 
 ## Prerequisites
 
@@ -88,7 +89,7 @@ Continue on to the [Running `ansible-test`](#running-ansible-test) section.
     ```sh
     source ~/ansible/bin/activate
     cd ~/.ansible/collections/ansible_collections/chocolatey/chocolatey
-    ansible-test windows-integration -vvvv --inventory vagrant-inventory.winrm --requirements --continue-on-error
+    ansible-test windows-integration --inventory /home/vagrant/.ansible/collections/ansible_collections/chocolatey/chocolatey/tests/integration/vagrant-inventory.winrm --requirements --continue-on-error
     ```
 
 1. To retrieve the test files from the Ansible server VM when using Vagrant, copy the test result files to the `/vagrant/results` shared folder to retrieve them from the Linux VM:

--- a/testing-chocolatey/local-testing.md
+++ b/testing-chocolatey/local-testing.md
@@ -91,6 +91,10 @@ Continue on to the [Running `ansible-test`](#running-ansible-test) section.
     cd ~/.ansible/collections/ansible_collections/chocolatey/chocolatey
     ansible-test windows-integration --inventory /home/vagrant/.ansible/collections/ansible_collections/chocolatey/chocolatey/tests/integration/vagrant-inventory.winrm --requirements --continue-on-error
     ```
+    or to start a specific test:
+    ```
+    ansible-test windows-integration --inventory /home/vagrant/.ansible/collections/ansible_collections/chocolatey/chocolatey/tests/integration/vagrant-inventory.winrm --requirements --continue-on-error --start-at win_chocolatey_facts
+    ```
 
 1. To retrieve the test files from the Ansible server VM when using Vagrant, copy the test result files to the `/vagrant/results` shared folder to retrieve them from the Linux VM:
 

--- a/testing-chocolatey/local-testing.md
+++ b/testing-chocolatey/local-testing.md
@@ -6,6 +6,7 @@
     - [Vagrant](#vagrant)
     - [Generic](#generic)
   - [Running `ansible-test`](#running-ansible-test)
+    - [Open issues](#open-issues)
 
 ## Prerequisites
 
@@ -115,3 +116,8 @@ npm install xunit-viewer -g
 xunit-viewer -r ./results -o ./results/report.html
 Invoke-Item ./results/report.html
 ```
+
+### Open issues
+
+* [Vagrant environment does not load ansible.windows modules correctly](https://github.com/chocolatey/chocolatey-ansible/issues/71)
+


### PR DESCRIPTION
## Description Of Changes

Fix ntlm related errors when running the test environment on an OS that no longer supports md4. Also migrate away from the 'StefanScherer/windows_10' box as that box starts 'Windows Update' when Vagrant is still running. This happens when the box is created outside of normal office hours.

## Motivation and Context
I had some problems with the test environment of this repo on my Fedora laptop when I was working on https://github.com/chocolatey/chocolatey-ansible/pull/81.

When running vagrant up in the testing-chocolatey directory I got:

```
An error occurred executing a remote WinRM command.

Shell: Cmd
Command: hostname
Message: Digest initialization failed: initialization error
```

After some manual changes I got the servers running. I then got errors running the ansible-test command as describe in the testing-chocolatey/local-testing.md file. Error:

`ntlm: unsupported hash type md4`

I think both problems are related to md4 no longer being supported on Fedora.

## Testing
I successfully created the new test environment on my Fedora 36 laptop. Somebody should check if the new test environment is also created successfully created on a Window host.

## Change Types Made

* [x ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes: https://github.com/chocolatey/chocolatey-ansible/issues/83

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

