### PR TITLE
(#91) Filter null entries from packageVersions

### DIFF
--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -191,7 +191,7 @@ if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
     # allow_multiple, throw error. Ignore this if force is set.
     if ($state -eq "present" -and $null -ne $version -and -not $force) {
         foreach ($package in $name) {
-            $packageVersions = @($packageInfo.$package)
+            $packageVersions = @($packageInfo.$package | Where-Object { $_ })
 
             if ($packageVersions.Count -gt 0) {
                 if (-not $packageVersions.Contains($version) -and -not $allow_multiple) {

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -219,6 +219,37 @@
     that:
     - not remove_multiple_again is changed
 
+- name: install package with explicit version and state=present
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: present
+    version: 0.1.0
+  register: install_with_version_and_state_present
+
+- name: get result of install package with explicit version and state=present
+  win_command: choco.exe list --local-only --exact --limit-output {{ test_choco_package1|quote }}
+  register: install_with_version_and_state_present_actual
+
+- name: get package info of install package with explicit version and state=present
+  win_shell: Get-Content -Path '{{ test_choco_path }}\{{ test_choco_package1 }}-0.1.0.txt' -Raw
+  register: install_with_version_and_state_present_actual_info
+
+- name: assert install package with explicit version and state=present
+  assert:
+    that:
+    - install_with_version_and_state_present is changed
+    - install_with_version_and_state_present_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).allow_empty_checksums == False
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).force == False
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).force_x86 == False
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).ignore_checksums == False
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).install_args == None
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).override_args == False
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).package_params == {}
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).proxy_url == None
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).source == "normal"
+    - (install_with_version_and_state_present_actual_info.stdout|from_json).timeout == "2700000"
+
 - name: install package with params
   win_chocolatey:
     name: '{{ test_choco_package1 }}'


### PR DESCRIPTION
## Description Of Changes

* Added `Where-Object` filter to `packageVersions` declaration when attempting to install a specific version of a package to remove null or empty entries.

## Motivation and Context

Previously null entries weren't being filtered. This caused failures when attempting to install a specific version of a package since packageVersions.Count would unexpectedly be greater than 0.

## Testing
1. Exploratory testing of the proposed changes
1. Ran integration tests locally

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #91

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
