### PR TITLE
(#92) Remove usage of ::new for PS compatibility

### DIFF
--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -174,7 +174,7 @@ if ($state -in "absent", "reinstalled") {
 if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
     # When state=present and force=true, we just run the install step with the packages specified,
     # otherwise only install the packages that are not installed
-    $missingPackages = [System.Collections.Generic.List[string]]::new()
+    $missingPackages = [System.Collections.Generic.List[string]]@()
 
     if ($state -eq "present" -and $force) {
         $missingPackages.Add($name)


### PR DESCRIPTION
## Description Of Changes

- Remove usage of `::new()` in `win_chocolatey.ps1`

## Motivation and Context

Ansible supports PowerShell down to v3, and this collection should as well so we don't get parse errors when running module tasks.

## Testing

1. Test in CI, this is a tiny change.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #92

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
