### PR TITLE
(#90) Avoid indexing null array

### DIFF
--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -743,3 +743,12 @@
   assert:
     that:
       - (bootstrap_file_check.stdout|from_json).bootstrap
+
+- name: remove chocolatey package directory
+  win_file:
+    path: 'C:/ProgramData/chocolatey/lib/chocolatey'
+    state: absent
+
+- name: ensure we can still upgrade packages with chocolatey package files missing
+  name: chocolatey
+  state: upgrade


### PR DESCRIPTION
## Description Of Changes

- Handle null case and emit proper warning when looking for Chocolatey install version

## Motivation and Context

If the chocolatey package files are missing from the client machine, we will not be able to determine the version.

Ensure we handle the null case here and emit a (somewhat) useful warning.

## Testing

1. Added test to ensure if anyone has nodes in this state that installs/upgrades still work as expected.
2. Running tests in CI

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #90

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
