### PR TITLE
(maint) Remove pyopenssl requirement

### DIFF
--- a/build/Vagrantfile
+++ b/build/Vagrantfile
@@ -66,6 +66,17 @@ Vagrant.configure("2") do |config|
       # linked clones for speed and size
       vbox.linked_clone = true if Vagrant::VERSION >= '1.8.0'
     end
+
+    client.vm.provision "shell" do |ps|
+      ps.inline = <<-PS1
+        # Configure WinRM for Ansible
+        $installScript = Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1" -UseBasicParsing
+        & ([scriptblock]::Create($installScript))
+        # Enable CredSSP/https in WinRM
+        Enable-WSManCredSSP -Role Server -Force
+      PS1
+      ps.privileged = true
+    end
   end
 
   # Disable automatic box update checking. If you disable this, then

--- a/build/vagrant-dependencies.sh
+++ b/build/vagrant-dependencies.sh
@@ -26,7 +26,7 @@ pip3 install packaging
 pip3 install "Jinja2<3.1.0"
 pip3 install "$ANSIBLE_PACKAGE"
 
-ansible-galaxy collection install ansible.windows
+sudo ansible-galaxy collection install ansible.windows
 
 pip3 --version
 ansible --version

--- a/chocolatey/requirements.txt
+++ b/chocolatey/requirements.txt
@@ -1,2 +1,1 @@
-pyOpenSSL<22.0.0
 pywinrm

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -750,5 +750,6 @@
     state: absent
 
 - name: ensure we can still upgrade packages with chocolatey package files missing
-  name: chocolatey
-  state: upgrade
+  win_chocolatey:
+    name: chocolatey
+    state: upgrade


### PR DESCRIPTION
## Description Of Changes

- Remove `pyOpenSSL` requirement from the collection.
- Also small fix copied over from the 'local testing' vagrantfile to the vagrantfile used by Invoke-ColletionTests.ps1 that got that working again for me locally, and a small change to vagrant-dependencies.sh that made the tests all work correctly again so I was able to test it locally as well.

## Motivation and Context

Remove workaround for an issue in ansible-test that has since been fixed. This was only ever necessary due to an issue in a specific version of ansible-test that clashed with a version of pyOpenSSL and a change that was made in v22 of pyOpenSSL. I believe this issue should be resolved by now, so we should be OK to remove this and see if anything breaks.

## Testing

1. Testing in CI to ensure we test against all the ansible versions we need to be testing against.
2. Test locally using Invoke-CollectionTests.ps1

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

N/A, but also fixes #71

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
