### PR TITLE
win_chocolatey - Deprecate `allow_multiple` option

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   ChocoCIClient.ansibleUser: 'ansible-test'
 # ChocoCIClient.ansiblePassword: <secret>
   CollectionArtifactName: 'chocolatey.collection'
-  Package.Version: 24.6.26
+  Package.Version: 1.0.0
 
 trigger:
   batch: true

--- a/build/Invoke-CollectionTests.ps1
+++ b/build/Invoke-CollectionTests.ps1
@@ -142,7 +142,7 @@ process {
             }
 
             if (-not $env:PACKAGE_VERSION) {
-                $env:PACKAGE_VERSION = '24.6.26'
+                $env:PACKAGE_VERSION = '1.0.0'
             }
 
             vagrant ssh choco_ansible_server --command "sed -i 's/{{ REPLACE_VERSION }}/$env:PACKAGE_VERSION/g' ./chocolatey/galaxy.yml"

--- a/build/Start-VagrantEnvironment.ps1
+++ b/build/Start-VagrantEnvironment.ps1
@@ -42,7 +42,7 @@ process {
         }
 
         if (-not $env:PACKAGE_VERSION) {
-            $env:PACKAGE_VERSION = '24.6.26'
+            $env:PACKAGE_VERSION = '1.0.0'
         }
 
         vagrant ssh choco_ansible_server --command "sed -i 's/{{ REPLACE_VERSION }}/$env:PACKAGE_VERSION/g' ./chocolatey/galaxy.yml"

--- a/chocolatey/meta/runtime.yml
+++ b/chocolatey/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: '>=2.9.0'
+requires_ansible: '>=2.10.0'

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -30,7 +30,7 @@ function Get-ModuleSpec {
     @{
         options             = @{
             allow_empty_checksums = @{ type = "bool"; default = $false }
-            allow_multiple        = @{ type = "bool"; default = $false }
+            allow_multiple        = @{ type = "bool"; default = $false; removed_in_version = '2.0.0'; removed_from_collection = 'chocolatey.chocolatey' }
             allow_prerelease      = @{ type = "bool"; default = $false }
             bootstrap_script      = @{ type = "str"; aliases = "install_ps1", "bootstrap_ps1" }
             architecture          = @{ type = "str"; default = "default"; choices = "default", "x86" }

--- a/chocolatey/plugins/modules/win_chocolatey.py
+++ b/chocolatey/plugins/modules/win_chocolatey.py
@@ -35,6 +35,9 @@ options:
     version_added: '0.2.2'
   allow_multiple:
     description:
+    - This option is deprecated and will be removed in v2.0.0 of this collection.
+      Chocolatey CLI has L(deprecated side-by-side installations, https://github.com/chocolatey/choco/issues/2787)
+      as of its v1.2.0 release and plans to remove them in its v2.0.0 release.
     - Allow the installation of multiple packages when I(version) is specified.
     - Having multiple packages at different versions can cause issues if the
       package doesn't support this. Use at your own risk.


### PR DESCRIPTION
## Description Of Changes

- Deprecated the allow_multiple feature and add some info to the documentation entry for it as well

## Motivation and Context

See #94

## Testing

Make a new `playbook.yml` file in the `build/vagrant-files` directory with the following content:

```yaml
---

- name: Test allow_multiple deprecation warnings
  gather_facts: false
  hosts: all

  tasks:
    - name: Install a package with allow_multiple
      chocolatey.chocolatey.win_chocolatey:
        name: python
        version: 3.9.5
        allow_multiple: yes
        state: present
```

Follow the instructions in `build/README.md` and use `Start-VagrantEnvironment.ps1` to get the Vagrant environment up and running, and run the above playbook with `ansible-playbook`.

You should see a prominent deprecation warning displayed like so:

```
[DEPRECATION WARNING]: Param 'allow_multiple' is deprecated. See the module docs for more information. This feature will be removed from 
chocolatey.chocolatey in version 2.0.0. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?

## Related Issue

Fixes #94

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
