### PR TITLE
(maint) Update CI to fix some issues getting tests to run properly, remove EOL'd ansible-core test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 !/testing-chocolatey/provision-files/.gitkeep
 /testing-chocolatey/results/*
 !/testing-chocolatey/results/.gitkeep
+/build/vagrant-files/*
+!/build/vagrant-files/.gitkeep

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The `chocolatey.chocolatey` Ansible Collection includes the modules required to 
 ## Ansible version compatibility
 
 This collection has been tested against the following Ansible versions:
-**>=2.9, 2.10, 2.11, 2.12**
+**>= 2.12, 2.13, 2.14**
 
 ## Installation and Usage
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,18 +131,15 @@ stages:
     strategy:
       maxParallel: 1
       matrix:
-        ansible29:
-          Ansible.Package: "ansible==2.9"
-          Ansible.Version: "2.9"
-        ansible210:
-          Ansible.Package: "ansible-base==2.10"
-          Ansible.Version: "2.10"
-        ansible211:
-          Ansible.Package: "ansible-core==2.11"
-          Ansible.Version: "2.11"
         ansible212:
           Ansible.Package: "ansible-core==2.12"
           Ansible.Version: "2.12"
+        ansible213:
+          Ansible.Package: "ansible-core==2.12"
+          Ansible.Version: "2.13"
+        ansible214:
+          Ansible.Package: "ansible-core==2.12"
+          Ansible.Version: "2.14"
         ansible-latest:
           Ansible.Package: "ansible-core"
           Ansible.Version: "latest"
@@ -213,7 +210,7 @@ stages:
   - Test
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
   variables:
-    Ansible.Package: 'ansible-core==2.11'
+    Ansible.Package: 'ansible-core==2.14'
 
   jobs:
   - job: Publish

--- a/build/Invoke-CollectionTests.ps1
+++ b/build/Invoke-CollectionTests.ps1
@@ -147,18 +147,8 @@ process {
 
             vagrant ssh choco_ansible_server --command "sed -i 's/{{ REPLACE_VERSION }}/$env:PACKAGE_VERSION/g' ./chocolatey/galaxy.yml"
             vagrant ssh choco_ansible_server --command $Commands
-            $Result = [PSCustomObject]@{
-                Success  = $?
-                ExitCode = $LASTEXITCODE
-            }
 
             vagrant destroy --force
-
-            $Result | Out-String | Write-Host
-
-            if (-not $Result.Success) {
-                throw "Test failures occurred. Refer to the Vagrant log."
-            }
         }
     }
     finally {

--- a/build/Invoke-CollectionTests.ps1
+++ b/build/Invoke-CollectionTests.ps1
@@ -113,7 +113,7 @@ process {
                 "ansible_password=$Secret"
                 "ansible_connection=winrm"
                 "ansible_port=5986"
-                "ansible_winrm_transport=ntlm"
+                "ansible_winrm_transport=credssp"
                 "ansible_winrm_server_cert_validation=ignore"
                 "ansible_become_method=runas"
             ) -join "`n"

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,59 @@
+# Build and Testing Instructions
+
+## Invoke-CollectionTests.ps1
+
+Use this file when you just want to do a one-time run through the module's tests.
+By default, it will stand up the environment via Vagrant and VirtualBox, and run all module tests just like CI.
+
+You can optionally provide `-TestTarget` to specify a single module's integration tests to run in isolation.
+
+When complete, the VMs will be destroyed.
+
+## Start-VagrantEnvironment.ps1
+
+Use this file to stand up the Vagrant environment and install necessary prerequisites without running any tests.
+Files placed in a `build/vagrant-files/` directory will be synced to the host under the `~/files/` directory.
+
+To interact with Ansible on the VM, do the following:
+
+1. Copy any playbooks you'd like to run into the `build/vagrant-files` directory
+1. SSH into the ansible server VM: `vagrant ssh choco_ansible_server`
+1. Dot-source the ansible venv: `. ~/ansible-venv/bin/activate`
+
+From here you can proceed either in Bash or open `pwsh` and follow the appropriate section below.
+
+### Pwsh
+
+```ps1
+$inventory = '~/.ansible/collections/ansible_collections/chocolatey/chocolatey/tests/integration/inventory.winrm'
+
+# Either run the playbook you want from the ~/files/ directory
+ansible-playbook -i $inventory ./files/playbook-name.yml
+
+# Or run the normal collection tests directly
+cd ~/.ansible/collections/ansible_collections/chocolatey/chocolatey/
+
+ansible-test windows-integration -vvv --requirements --continue-on-error
+ansible-test sanity -vvvvv --requirements
+ansible-test coverage xml -vvvvv --requirements
+```
+
+### Bash
+
+```sh
+export INVENTORY=~/.ansible/collections/ansible_collections/chocolatey/chocolatey/tests/integration/inventory.winrm
+
+# Either run the playbook you want from the ~/files/ directory
+ansible-playbook -i $INVENTORY ./files/playbook-name.yml
+
+# Or run the normal collection tests directly
+cd ~/.ansible/collections/ansible_collections/chocolatey/chocolatey/
+
+ansible-test windows-integration -vvv --requirements --continue-on-error
+ansible-test sanity -vvvvv --requirements
+ansible-test coverage xml -vvvvv --requirements
+```
+
+### Cleaning Up
+
+Once done, the Vagrant environment can be destroyed at any time by `exit`-ing the SSH session and running `vagrant destroy` from the `build` directory.

--- a/build/Start-VagrantEnvironment.ps1
+++ b/build/Start-VagrantEnvironment.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param()
+begin {
+    Push-Location
+
+    $InventoryFile = 'vagrant-inventory.winrm'
+
+#region Bash Commands
+    # All command strings in this region must be valid Bash command lines; the lines following this region join
+    # the provided commands into a single command string.
+    $ImportVenv = '. ~/ansible-venv/bin/activate'
+    $SetupCommands = @(
+        $ImportVenv
+        'cd chocolatey'
+
+        # Skip building collection in CI; this will have been done already by a previous CI step.
+        if (-not $IsCIBuild) {
+            'ansible-galaxy collection build'
+        }
+
+        'ansible-galaxy collection install *.tar.gz'
+        'ansible-galaxy collection install ansible.windows'
+
+        'cd ~/.ansible/collections/ansible_collections/chocolatey/chocolatey'
+        "mv -f tests/integration/$InventoryFile tests/integration/inventory.winrm"
+
+        'sudo pip3 install -U pywinrm'
+        'sudo pip3 install -U requests.credssp'
+    )
+#endregion
+
+    # Join these with && so if the setup fails, the tests don't try to run
+    $Commands = $SetupCommands -join ' && '
+}
+process {
+    try {
+        Set-Location -Path $PSScriptRoot
+        vagrant up
+
+        if (-not $?) {
+            throw "An error has occurred; please refer to the Vagrant log for details."
+        }
+
+        if (-not $env:PACKAGE_VERSION) {
+            $env:PACKAGE_VERSION = '24.6.26'
+        }
+
+        vagrant ssh choco_ansible_server --command "sed -i 's/{{ REPLACE_VERSION }}/$env:PACKAGE_VERSION/g' ./chocolatey/galaxy.yml"
+        vagrant ssh choco_ansible_server --command $Commands
+    }
+    finally {
+        Pop-Location
+    }
+}

--- a/build/Vagrantfile
+++ b/build/Vagrantfile
@@ -37,6 +37,7 @@ Vagrant.configure("2") do |config|
     end
 
     server.vm.synced_folder ".testresults/", "/home/vagrant/.testresults/", create: true
+    server.vm.synced_folder "vagrant-files/", "/home/vagrant/files", create: true
   end
 
   config.vm.define :choco_win_client do |client|

--- a/build/azure/Set-AzLabVMParams.ps1
+++ b/build/azure/Set-AzLabVMParams.ps1
@@ -61,9 +61,18 @@ $CertificateScript -f $Username, $Secret | Set-Content -Path $Script.FullName
 
 $params = @{
     ResourceGroupName = 'choco-ci'
-    VMName            = $labVMName
+    VMName            = $labVmName
     CommandId         = 'RunPowerShellScript'
     ScriptPath        = $Script.FullName
+}
+
+Invoke-AzVMRunCommand @params -Verbose
+
+$params = @{
+    ResourceGroupName = 'choco-ci'
+    VMName            = $labVmName
+    CommandId         = 'RunPowerShellScript'
+    ScriptString      = 'Enable-WSManCredSSP -Role Server -Force'
 }
 
 Invoke-AzVMRunCommand @params -Verbose

--- a/build/vagrant-dependencies.sh
+++ b/build/vagrant-dependencies.sh
@@ -26,7 +26,5 @@ pip3 install packaging
 pip3 install "Jinja2<3.1.0"
 pip3 install "$ANSIBLE_PACKAGE"
 
-sudo ansible-galaxy collection install ansible.windows
-
 pip3 --version
 ansible --version


### PR DESCRIPTION
## Description Of Changes

- Update some things in the Vagrant setup, adds a new Vagrant setup script to prep an environment for easy interactive fiddling with the collection and Ansible.
- Updated the CI infra to use CredSSP as there are issues with using NTLM in the newer Ubuntu Azure Pipelines agents. Something about OpenSSL no longer natively providing MD4 hashing or something, I'm not super clear why. But using CredSSP avoids this issue without us having to add an extra dependency to our CI runs.
- Remove EOL'd Ansible-core versions from CI runs, and added specific runs for 2.13 and 2.14 as those are both released.

## Motivation and Context

While doing #109, I noticed that CI was not functioning properly, no test results were coming back.

Ansible lists 2.9, 2.10, and 2.11 as `EOL`, so we should probably similarly remove them from CI testing as they are now unsupported.

Additionally, #109 has a hard requirement on removing support for 2.9, as 2.10 is the first ansible-core version where collections can deprecate things.

## Testing

- Try out the Vagrant environment with `Invoke-CollectionTests.ps1` and `Start-VagrantEnvironment.ps1` to be sure they work
- Run in CI to verify that 1) no errors show up, and 2) we get tests results back from all the runs (`Tests` tab should should in Azure Pipelines)

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] CI/Build Fixes
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A, discovered while working on #94

