### PR TITLE
(maint) Update ansible-core versions tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The `chocolatey.chocolatey` Ansible Collection includes the modules required to 
 ## Ansible version compatibility
 
 This collection has been tested against the following Ansible versions:
-**>= 2.12, 2.13, 2.14**
+**>= 2.13, 2.14, 2.15**
 
 ## Installation and Usage
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,15 +131,15 @@ stages:
     strategy:
       maxParallel: 1
       matrix:
-        ansible212:
-          Ansible.Package: "ansible-core==2.12"
-          Ansible.Version: "2.12"
         ansible213:
-          Ansible.Package: "ansible-core==2.12"
+          Ansible.Package: "ansible-core==2.13"
           Ansible.Version: "2.13"
         ansible214:
-          Ansible.Package: "ansible-core==2.12"
+          Ansible.Package: "ansible-core==2.14"
           Ansible.Version: "2.14"
+        ansible215:
+          Ansible.Package: "ansible-core==2.15"
+          Ansible.Version: "2.15"
         ansible-latest:
           Ansible.Package: "ansible-core"
           Ansible.Version: "latest"


### PR DESCRIPTION
## Description Of Changes

- Add Ansible-core 2.15 to the testing matrix
- Remove Ansible-core 2.12 from the testing matrix
- Fix pip package version specifiers, not sure how long _that's_ been there

## Motivation and Context

Ansible 2.12 was EOL'd in May, and Ansible 2.15 is the current stable version.

## Testing

Testing in CI

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

N/A, maint only

