### PR TITLE
(#114) Add checksum options

### DIFF
--- a/chocolatey/plugins/module_utils/Packages.psm1
+++ b/chocolatey/plugins/module_utils/Packages.psm1
@@ -270,6 +270,28 @@ function ConvertTo-ChocolateyArgument {
         [string]
         $Architecture,
 
+        # Specify to override package checksum.
+        [Parameter()]
+        [string]
+        $Checksum,
+
+        # Specify to override package checksum for x64 installers.
+        [Parameter()]
+        [string]
+        $Checksum64,
+
+        # Specify to override package checksum type.
+        [Parameter()]
+        [ValidateSet('md5', 'sha1', 'sha256', 'sha512')]
+        [string]
+        $ChecksumType,
+
+        # Specify to override package checksum type for x64 installers.
+        [Parameter()]
+        [ValidateSet('md5', 'sha1', 'sha256', 'sha512')]
+        [string]
+        $ChecksumType64,
+
         # Any additional arguments to be passed directly to `choco.exe`
         [Parameter()]
         [string[]]
@@ -364,6 +386,10 @@ function ConvertTo-ChocolateyArgument {
     if ($AllowMultiple) { "--allow-multiple" }
     if ($AllowPrerelease) { "--prerelease" }
     if ($Architecture -eq "x86") { "--x86" }
+    if ($Checksum) { '--checksum', $Checksum }
+    if ($Checksum64) { '--checksum64', $Checksum64 }
+    if ($ChecksumType) { '--checksumtype', $ChecksumType }
+    if ($ChecksumType64) { '--checksumtype64', $ChecksumType64 }
     if ($Force) { "--force" }
     if ($IgnoreChecksums) { "--ignore-checksums" }
     if ($IgnoreDependencies) { "--ignore-dependencies" }
@@ -541,6 +567,28 @@ function Update-ChocolateyPackage {
         [string]
         $Architecture,
 
+        # Specify to override package checksum.
+        [Parameter()]
+        [string]
+        $Checksum,
+
+        # Specify to override package checksum for x64 installers.
+        [Parameter()]
+        [string]
+        $Checksum64,
+
+        # Specify to override package checksum type.
+        [Parameter()]
+        [ValidateSet('md5', 'sha1', 'sha256', 'sha512')]
+        [string]
+        $ChecksumType,
+
+        # Specify to override package checksum type for x64 installers.
+        [Parameter()]
+        [ValidateSet('md5', 'sha1', 'sha256', 'sha512')]
+        [string]
+        $ChecksumType64,
+
         # Any additional arguments to be passed directly to `choco.exe`
         [Parameter()]
         [string[]]
@@ -710,6 +758,28 @@ function Install-ChocolateyPackage {
         [Parameter()]
         [string]
         $Architecture,
+
+        # Specify to override package checksum.
+        [Parameter()]
+        [string]
+        $Checksum,
+
+        # Specify to override package checksum for x64 installers.
+        [Parameter()]
+        [string]
+        $Checksum64,
+
+        # Specify to override package checksum type.
+        [Parameter()]
+        [ValidateSet('md5', 'sha1', 'sha256', 'sha512')]
+        [string]
+        $ChecksumType,
+
+        # Specify to override package checksum type for x64 installers.
+        [Parameter()]
+        [ValidateSet('md5', 'sha1', 'sha256', 'sha512')]
+        [string]
+        $ChecksumType64,
 
         # Any additional arguments to be passed directly to `choco.exe`
         [Parameter()]

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -245,8 +245,6 @@ if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
         Architecture = $architecture
         Checksum = $checksum
         Checksum64 = $checksum64
-        ChecksumType = $checksum_type
-        ChecksumType64 = $checksum_type64
         ChocoArgs = $choco_args
         Force = $force
         IgnoreChecksums = $ignore_checksums
@@ -263,6 +261,14 @@ if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
         SourcePassword = $source_password
         Timeout = $timeout
         Version = $version
+    }
+
+    if ($checksum_type -and $checksum_type -ne '') {
+        $commonParams.Add('ChecksumType', $checksum_type)
+    }
+
+    if ($checksum_type64 -and $checksum_type64 -ne '') {
+        $commonParams.Add('ChecksumType64', $checksum_type64)
     }
 
     if ($missingPackages.Count -gt 0) {

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -32,6 +32,7 @@ function Get-ModuleSpec {
             allow_empty_checksums = @{ type = "bool"; default = $false }
             allow_multiple        = @{ type = "bool"; default = $false; removed_in_version = '2.0.0'; removed_from_collection = 'chocolatey.chocolatey' }
             allow_prerelease      = @{ type = "bool"; default = $false }
+            architecture          = @{ type = "str"; default = "default"; choices = "default", "x86" }
             bootstrap_script      = @{ type = "str"; aliases = "install_ps1", "bootstrap_ps1" }
             bootstrap_tls_version = @{
                 type = "list"
@@ -40,7 +41,10 @@ function Get-ModuleSpec {
                 default = "tls12", "tls13"
                 aliases = "tls_version", "tls_versions", "bootstrap_tls_versions"
             }
-            architecture          = @{ type = "str"; default = "default"; choices = "default", "x86" }
+            checksum              = @{ type = "str" }
+            checksum64            = @{ type = "str" }
+            checksum_type         = @{ type = "str"; choices = "md5", "sha1", "sha256", "sha512" }
+            checksum_type64       = @{ type = "str"; choices = "md5", "sha1", "sha256", "sha512" }
             choco_args            = @{ type = "list"; elements = "str"; aliases = "licensed_args" }
             force                 = @{ type = "bool"; default = $false }
             ignore_checksums      = @{ type = "bool"; default = $false }
@@ -77,6 +81,10 @@ $allow_multiple = $module.Params.allow_multiple
 $allow_prerelease = $module.Params.allow_prerelease
 $architecture = $module.Params.architecture
 $bootstrap_script = $module.Params.bootstrap_script
+$checksum = $module.Params.checksum
+$checksum64 = $module.Params.checksum64
+$checksum_type = $module.Params.checksum_type
+$checksum_type64 = $module.Params.checksum_type64
 $choco_args = $module.Params.choco_args
 $force = $module.Params.force
 $ignore_checksums = $module.Params.ignore_checksums
@@ -235,6 +243,10 @@ if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
         AllowMultiple = $allow_multiple
         AllowPrerelease = $allow_prerelease
         Architecture = $architecture
+        Checksum = $checksum
+        Checksum64 = $checksum64
+        ChecksumType = $checksum_type
+        ChecksumType64 = $checksum_type64
         ChocoArgs = $choco_args
         Force = $force
         IgnoreChecksums = $ignore_checksums

--- a/chocolatey/plugins/modules/win_chocolatey.py
+++ b/chocolatey/plugins/modules/win_chocolatey.py
@@ -100,6 +100,28 @@ options:
     default: [ tls12, tls13 ]
     version_added: '1.4.0'
     aliases: [ bootstrap_tls_versions, tls_version, tls_versions ]
+  checksum:
+    description:
+    - Override a package's checksums for files downloaded during installation.
+    - If the checksum is not MD5, you will need to specify the I(checksum_type) as well.
+    type: str
+    version_added: '1.5.0'
+  checksum_type:
+    description:
+    - Override a package's checksum type for files downloaded during install. Use in conjunction with I(checksum).
+    choices: [ md5, sha1, sha256, sha512 ]
+    version_added: '1.5.0'
+  checksum64:
+    description:
+    - Override a package's checksums for 64-bit files downloaded during installation.
+    - If the checksum is not MD5, you will need to specify the I(checksum_type64) as well.
+    type: str
+    version_added: '1.5.0'
+  checksum_type64:
+    description:
+    - Override a package's checksum type for files downloaded during install. Use in conjunction with I(checksum64).
+    choices: [ md5, sha1, sha256, sha512 ]
+    version_added: '1.5.0'
   force:
     description:
     - Forces the install of a package, even if it already is installed.

--- a/chocolatey/tests/integration/targets/setup_win_chocolatey/files/test-package/tools/chocolateyinstall.ps1
+++ b/chocolatey/tests/integration/targets/setup_win_chocolatey/files/test-package/tools/chocolateyinstall.ps1
@@ -50,6 +50,10 @@ $timeout = $env:chocolateyResponseTimeout
 
 $package_info = @{
     allow_empty_checksums = $allow_empty_checksums
+    checksum = $env:ChocolateyChecksum32
+    checksum_type = $env:ChocolateyChecksumType32
+    checksum64 = $env:ChocolateyChecksum64
+    checksum_type64 = $env:ChocolateyChecksumType64
     #env_vars = $env_vars
     force = $force
     force_x86 = $force_x86

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -685,3 +685,32 @@
     that:
     - not remove_nonexistent_version is changed
     - '"{{ test_choco_package1 }}|0.1.0" in remove_nonexistent_version_result.stdout_lines'
+
+- name: install package with checksum overrides
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: present
+    checksum: 96e27a3dbef8b4a9f890162c475b9192fee6c9b9
+    checksum_type: sha1
+    checksum64: a3a1f075f5b0e9ee7cd2ba33afbb5f67b9e335117ef3ea352fc361b098aecad4
+    checksum_type64: sha256
+    force: true
+  register: checksum
+
+- name: get result of install package with checksum overrides
+  win_command: choco.exe list --exact --limit-output {{ test_choco_package1|quote }}
+  register: checksum_actual
+
+- name: get package info of install package with checksum overrides
+  win_shell: Get-Content -Path '{{ test_choco_path }}\{{ test_choco_package1 }}-0.1.0.txt' -Raw
+  register: checksum_actual_info
+
+- name: assert install package with checksum overrides
+  assert:
+    that:
+    - checksum is changed
+    - checksum_actual.stdout_lines == [test_choco_package1 + "|0.1.0"]
+    - (checksum_actual_info.stdout|from_json).checksum == "96e27a3dbef8b4a9f890162c475b9192fee6c9b9"
+    - (checksum_actual_info.stdout|from_json).checksum_type == "sha1"
+    - (checksum_actual_info.stdout|from_json).checksum64 == "a3a1f075f5b0e9ee7cd2ba33afbb5f67b9e335117ef3ea352fc361b098aecad4"
+    - (checksum_actual_info.stdout|from_json).checksum_type64 == "sha256"


### PR DESCRIPTION
## Description Of Changes

- Add options to win_chocolatey to allow the user to specify the checksum and type for package installs

## Motivation and Context

Allow users to specify the checksum and type to be used for package installs and upgrades.

## Testing

- CI tests added
- Can be tested in the local vagrant env by attempting a normal package install of something that requires downloading the installer (googlechrome, firefox, etc), and then attempting again while overriding the checksums or the checksum types with junk data and watching it crash and burn :3

### Operating Systems Testing

Win10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [x] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #114

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
