### PR TITLE
(108) Add filter parameter to win_chocolatey_facts module

### DIFF
--- a/chocolatey/plugins/modules/win_chocolatey_facts.py
+++ b/chocolatey/plugins/modules/win_chocolatey_facts.py
@@ -18,6 +18,18 @@ version_added: '0.2.8'
 short_description: Create a facts collection for Chocolatey
 description:
 - This module shows information from Chocolatey, such as installed packages, outdated packages, configuration, feature and sources.
+options:
+  filter:
+    version_added: "1.5.0"
+    description:
+    - "If supplied, restrict the facts collected to the given subset.
+      Possible values: C(all), C(config), C(feature), C(outdated),
+      C(packages), C(sources)."
+    - You can provide a list of values to specify a larger subset.
+    type: list
+    elements: str
+    default: "all"
+    aliases: [ gather_subset ]
 notes:
 - Chocolatey must be installed beforehand, use M(chocolatey.chocolatey.win_chocolatey) to do this.
 seealso:
@@ -55,6 +67,31 @@ EXAMPLES = r'''
 - name: Displays the Outdated packages
   debug:
     var: ansible_chocolatey.outdated
+
+- name: Gather all facts from chocolatey, except outdated packages
+  win_chocolatey_facts:
+    filter:
+    - 'config'
+    - 'feature'
+    - 'packages'
+    - 'sources'
+
+- name: Displays the collected facts from chocolatey without the outdated packages
+  debug:
+    var: ansible_chocolatey
+
+- name: Clear existing facts from chocolatey
+  ansible.builtin.meta: clear_facts
+
+- name: Gather config and feature facts only from chocolatey
+  win_chocolatey_facts:
+    filter:
+    - 'config'
+    - 'feature'
+
+- name: Displays the collected config and feature facts from chocolatey
+  debug:
+    var: ansible_chocolatey
 '''
 
 RETURN = r'''
@@ -70,14 +107,14 @@ ansible_facts:
       contains:
         config:
           description: Detailed information about stored the configurations
-          returned: always
+          returned: always (except when filter is set to exclude config)
           type: dict
           sample:
             commandExecutionTimeoutSeconds: 2700
             containsLegacyPackageInstalls: true
         feature:
           description: Detailed information about enabled and disabled features
-          returned: always
+          returned: always (except when filter is set to exclude feature)
           type: dict
           sample:
             allowEmptyCheckums: false
@@ -85,7 +122,7 @@ ansible_facts:
             failOnAutoUninstaller: false
         sources:
           description: List of Chocolatey sources
-          returned: always
+          returned: always (except when filter is set to exclude sources)
           type: complex
           contains:
             admin_only:
@@ -133,9 +170,16 @@ ansible_facts:
               returned: always
               type: str
               sample: username
+        filter:
+          description: The list of subsets that were gathered
+          returned: always
+          type: list
+          elements: str
+          sample: ['all']
+          version_added: '1.5.0'
         packages:
           description: List of installed Packages
-          returned: always
+          returned: always (except when filter is set to exclude packages)
           type: complex
           contains:
             package:
@@ -150,7 +194,7 @@ ansible_facts:
               sample: '1.27.2'
         outdated:
           description: List of packages for which an update is available
-          returned: always
+          returned: always (except when filter is set to exclude outdated)
           type: complex
           version_added: '1.3.0'
           contains:

--- a/chocolatey/tests/integration/targets/win_chocolatey_facts/tasks/main.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey_facts/tasks/main.yml
@@ -94,3 +94,7 @@
     - ansible_chocolatey.sources[1].priority == 9
     - ansible_chocolatey.sources[1].source == 'http://test-server/chocolatey'
     - ansible_chocolatey.sources[1].source_username == 'test-user'
+
+# Testing of the new gather_subset option has been isolated to its own file
+- name: win_chocolatey_fact gather_subset option tests
+  include_tasks: test_gather_facts.yml

--- a/chocolatey/tests/integration/targets/win_chocolatey_facts/tasks/test_gather_facts.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey_facts/tasks/test_gather_facts.yml
@@ -1,0 +1,71 @@
+---
+- name: Ensure there are no facts from previous tests
+  ansible.builtin.meta: clear_facts
+
+- name: Gather all facts, with implied "all" filter
+  win_chocolatey_facts:
+
+- name: assert all chocolatey facts are gathered 
+  assert:
+    that:
+    - ansible_chocolatey is not changed
+    - ansible_chocolatey.outdated is defined
+    - ansible_chocolatey.config is defined
+    - ansible_chocolatey.feature is defined
+    - ansible_chocolatey.packages is defined
+    - ansible_chocolatey.sources is defined
+    - '"config" not in ansible_chocolatey.filter'
+    - '"feature" not in ansible_chocolatey.filter'
+    - '"packages" not in ansible_chocolatey.filter'
+    - '"sources" not in ansible_chocolatey.filter'
+    - '"outdated" not in ansible_chocolatey.filter'
+    - '"all" in ansible_chocolatey.filter'
+
+- name: Ensure there are no facts from previous tests
+  ansible.builtin.meta: clear_facts
+
+- name: Gather facts, except outdated packages
+  win_chocolatey_facts:
+    filter:
+    - 'config'
+    - 'feature'
+    - 'packages'
+    - 'sources'
+
+- name: assert all chocolatey facts except for outdated packages are gathered
+  assert:
+    that:
+    - ansible_chocolatey is not changed
+    - ansible_chocolatey.outdated is not defined
+    - ansible_chocolatey.config is defined
+    - ansible_chocolatey.feature is defined
+    - ansible_chocolatey.packages is defined
+    - ansible_chocolatey.sources is defined
+    - '"config" in ansible_chocolatey.filter'
+    - '"feature" in ansible_chocolatey.filter'
+    - '"packages" in ansible_chocolatey.filter'
+    - '"sources" in ansible_chocolatey.filter'
+    - '"outdated" not in ansible_chocolatey.filter'
+    - '"all" not in ansible_chocolatey.filter'
+
+- name: Ensure there are no facts from previous tests
+  ansible.builtin.meta: clear_facts
+
+- name: Gather config and feature facts only
+  win_chocolatey_facts:
+    filter:
+    - 'config'
+    - 'feature'
+
+- name: assert only config and feature chocolatey facts are gathered
+  assert:
+    that:
+    - ansible_chocolatey is not changed
+    - ansible_chocolatey.config is defined
+    - ansible_chocolatey.feature is defined
+    - ansible_chocolatey.outdated is not defined
+    - ansible_chocolatey.packages is not defined
+    - ansible_chocolatey.sources is not defined
+    - '"config" in ansible_chocolatey.filter'
+    - '"feature" in ansible_chocolatey.filter'
+    - '"all" not in ansible_chocolatey.filter'


### PR DESCRIPTION
## Description Of Changes

This PR adds a `gather_subset` parameter to the win_chocolatey_facts module which allows the user to "gather" only a subset of facts.

## Motivation and Context

Currently the win_chocolatey_facts module gets ALL facts available to it, including:
- All config settings
- All features
- Sources
- Installed packages
- Outdated packages

This means there is a lot of information being complied even if the user doesn't need it. This can be especially egregious when pulling the outdated packages when the target has a large number of packages installed.

`gather_subset` is an established pattern when gathering general Ansible facts, see [Gathers facts about remote hosts](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html#parameter-gather_subset), and the implementation in this module emulates this existing pattern as closely as makes sense.

## Testing

I have built and tested the collection locally, it has also been tested via the Azure DevOps pipeline:
![Azure Pipeline Test Results (Passing)](https://github.com/chocolatey/chocolatey-ansible/assets/6955786/3be32c15-32ba-454c-874c-ca5d59f4a8c9)

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [X] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [X] Requires a change to the documentation.
* [X] Documentation has been updated.
* [X] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #108
