### PR TITLE
(#132) Ensure only Chocolatey CLI version number is processed through Get-ChocolateyVersion function

### DIFF
--- a/chocolatey/plugins/module_utils/Packages.psm1
+++ b/chocolatey/plugins/module_utils/Packages.psm1
@@ -193,6 +193,8 @@ function Get-ChocolateyVersion {
     # Also, if a license is installed, but the licensed extension is missing,
     # choco.exe output will contain an error which we need to ignore for the
     # purposes of determining the version of Chocolatey CLI.
+    # We're using the suggested regex for matching SemVer strings:
+    # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
     $SemVerRegex = '(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?'
     if ($result.stdout -match $SemVerRegex) {
         ($script:ChocolateyVersion = [version]($matches[0] -replace '-.+$'))

--- a/chocolatey/plugins/module_utils/Packages.psm1
+++ b/chocolatey/plugins/module_utils/Packages.psm1
@@ -190,7 +190,17 @@ function Get-ChocolateyVersion {
 
     # Prerelease versions are not relevant for our purposes.
     # Stripping off any prerelease tag here gets us enough for what we need.
-    ($script:ChocolateyVersion = [version]($result.stdout -replace '-.+$'))
+    # Also, if a license is installed, but the licensed extension is missing,
+    # choco.exe output will contain an error which we need to ignore for the
+    # purposes of determining the version of Chocolatey CLI.
+    $SemVerRegex = '(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?'
+    if ($result.stdout -match $SemVerRegex) {
+        ($script:ChocolateyVersion = [version]($matches[0] -replace '-.+$'))
+    }
+    else {
+        $message = "Error getting version of Chocolatey CLI"
+        Assert-TaskFailed -Message $message -Command $command -CommandResult $result
+    }
 }
 
 function Get-CommonChocolateyArgument {


### PR DESCRIPTION
## Description Of Changes

This PR ensures that the `Get-ChocolateyVersion` function only attempts to cast the Chocolatey CLI version number as a `version` object.

To achieve this the `stdout` from executing `choco --version` is matches against the [recommended regular expression](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string) for checking SemVer strings.

## Motivation and Context

When a Chocolatey for Business or Pro license is installed on a system but the licensed extension package is not yet installed, additional information is presented to the user.

This pollutes the `stdout` stream meaning that it is not possible to directly cast the information on this stream and a `version` object.

Instead, the stream is matched against a regular expression representing a valid SemVer string, and then the match (if found) is processed.

If for any reason the regular expression does not match, the function will now assert that the task has failed. This should make diagnosing failures easier.

## Testing

I have tested this against a Windows Server 2016 VM where I have installed and uninstalled packages with and without a license installed (and the licensed extension missing).

I have repeated these tests on both Chocolatey CLI 1.4.0 and 2.1.0.

### Operating Systems Testing

- Windows Server 2016

## Change Types Made

* [X] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #132
