### PR TITLE
Add -NoNewline to the Set-Content call

### DIFF
--- a/chocolatey/plugins/module_utils/Packages.psm1
+++ b/chocolatey/plugins/module_utils/Packages.psm1
@@ -1188,7 +1188,7 @@ function Install-Chocolatey {
 
         if (-not $Module.CheckMode) {
             $scriptFile = New-Item -Path (Join-Path $Module.TmpDir -ChildPath 'chocolateyInstall.ps1') -ItemType File
-            $installScript | Set-Content -Path $scriptFile
+            $installScript | Set-Content -Path $scriptFile -NoNewline
 
             # These commands will be sent over stdin for the PowerShell process, and will be read line by line,
             # so we must join them on \r\n line-feeds to have them read as separate commands.


### PR DESCRIPTION
Add -NoNewline to the Set-Content call to avoid adding an extra newline to install.ps1 voiding the signature

## Description Of Changes
Set-Content is adding a newline to the end of the install.ps1 file.

This is not PowerShell v2 compliant, so not sure how to handle that.

## Motivation and Context
Breaks the signature of the file

## Testing
```
- hosts: windows
  gather_facts: false
  tasks:
    - name: "Install chocolatey"
      win_chocolatey:
        name:
          - chocolatey
        state: latest
```

### Operating Systems Testing
Windows 11 Enterprise

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [X] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [!] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
Fixes #141
