### PR TITLE
(build) Bump required Jinja2 version for build and test pipelines

### DIFF
--- a/build/azure/client-template.json
+++ b/build/azure/client-template.json
@@ -41,11 +41,11 @@
             "location": "[resourceGroup().location]",
             "properties": {
                 "labVirtualNetworkId": "[variables('labVirtualNetworkId')]",
-                "notes": "Windows 10 Enterprise, Version 1909",
+                "notes": "Windows 10 Enterprise, Version 21H2",
                 "galleryImageReference": {
                     "offer": "Windows-10",
                     "publisher": "MicrosoftWindowsDesktop",
-                    "sku": "19h2-ent",
+                    "sku": "win10-21h2-ent",
                     "osType": "Windows",
                     "version": "latest"
                 },

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -22,7 +22,7 @@ source ~/ansible-venv/bin/activate
 pip3 install --upgrade pip
 pip3 install --upgrade wheel
 pip3 install packaging
-pip3 install "Jinja2<3.1.0"
+pip3 install "Jinja2~>3.1.3"
 pip3 install "$ANSIBLE_PACKAGE"
 
 ansible-galaxy collection install ansible.windows

--- a/build/vagrant-dependencies.sh
+++ b/build/vagrant-dependencies.sh
@@ -23,7 +23,7 @@ virtualenv /home/vagrant/ansible-venv
 pip3 install --upgrade pip
 pip3 install --upgrade wheel
 pip3 install packaging
-pip3 install "Jinja2<3.1.0"
+pip3 install "Jinja2~>3.1.3"
 pip3 install "$ANSIBLE_PACKAGE"
 
 pip3 --version

--- a/chocolatey/tests/requirements.txt
+++ b/chocolatey/tests/requirements.txt
@@ -1,2 +1,2 @@
 ansible.windows
-Jinja2<3.1.0
+Jinja2~>3.1.3


### PR DESCRIPTION
## Description Of Changes

This MR bumps the required Jinja2 version used in the build and test pipelines to `~>3.1.3` (and version from 3.1.3 through 3.1.x)

## Motivation and Context

Versions of Jinja2 below 3.1.3 are affected by [CVE-2024-22195](https://access.redhat.com/security/cve/cve-2024-22195)

This MR also updates the Azure Windows Client image used in the Azure Pipeline as the previous one had been removed.

## Testing

This change has been exercised through the Azure Pipeline and resulted in a successful build and test.

### Operating Systems Testing

N/A

## Change Types Made

Build change
~~* [ ] Bug fix (non-breaking change).~~
~~* [ ] Feature / Enhancement (non-breaking change).~~
~~* [ ] Breaking change (fix or feature that could cause existing functionality to change).~~
~~* [ ] Documentation changes.~~
~~* [ ] PowerShell code changes.~~

## Change Checklist

~~* [ ] Requires a change to the documentation.~~
~~* [ ] Documentation has been updated.~~
~~* [ ] Tests to cover my changes, have been added.~~
~~* [ ] All new and existing tests passed?~~
~~* [ ] PowerShell code changes: PowerShell v2 compatibility checked?~~

## Related Issue

N/A