### PR TITLE
Fix crashing when PATH contains multiple choco installations

### DIFF
--- a/chocolatey/plugins/module_utils/Common.psm1
+++ b/chocolatey/plugins/module_utils/Common.psm1
@@ -54,7 +54,7 @@ function Get-ChocolateyCommand {
         $IgnoreMissing
     )
 
-    $command = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue
+    $command = Get-Command -Name choco.exe -CommandType Application -ErrorAction SilentlyContinue -TotalCount 1
 
     if (-not $command) {
         $installDir = if ($env:ChocolateyInstall) {

--- a/chocolatey/plugins/modules/win_chocolatey.py
+++ b/chocolatey/plugins/modules/win_chocolatey.py
@@ -21,6 +21,7 @@ short_description: Manage packages using chocolatey
 description:
 - Manage packages using Chocolatey.
 - If Chocolatey is missing from the system, the module will install it.
+- If there are multiple installations of choco.exe in env:PATH, it will use the first found one
 requirements:
 - chocolatey >= 0.10.5 (will be upgraded if older)
 options:


### PR DESCRIPTION
When for some reason the path environment variable contains two installations of chocolatey this function will return a list, which causes a syntax error down the line. Since running choco.exe on the machine will also choose the first installation in the path, I think limiting the found installations to the first is the desired behavior here.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over [CONTRIBUTING.md](./CONTRIBUTING.md). We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER / MAIN branch.
 - You are able to sign the Contributor License Agreement (CLA).
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

Name your pull request appropriately: give it a sentence that reads well enough for anyone seeing this.

if you were explaining it to somebody else. This helps others to understand the reasons for the pull request and for it to be searchable in future.

Please do not remove any of the headings.
If a heading is not applicable then enter N/A: Why it's not applicable

Make sure you have raised an issue for this pull request before continuing.

Please remove all comments before submitting.
-->

## Description Of Changes
Restricted the output of Get-Command to the first finding
## Motivation and Context
I encountered a crashing win_chocolatey task, when on the target machine the path variable contained multiple choco installations. Limiting the finding to the first in the PATH, the same way it would be resolved in the powershell on the machine, fixes this problem. 
## Testing
I have tried this out before and after the change, the change fixes this issue
### Operating Systems Testing
- Windows 10
- Windows 11
## Change Types Made
* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue


Fixes #147

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
