### PR TITLE
(#164) Update requires_ansible to >=2.15.0

### DIFF
--- a/chocolatey/meta/runtime.yml
+++ b/chocolatey/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: '>=2.10.0'
+requires_ansible: '>=2.15.0'


### PR DESCRIPTION
## Description Of Changes

- Update the `requires_ansible` metadata

## Motivation and Context

RedHat are requiring this match their minimum supported ansible-core version in order to publish to Automation Hub.

## Testing

Metadata change only, I'm not sure what we can do to make sure this is tested going forward?

I've looked through [Ansible's testing documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_testing.html) and I'm not seeing anything that talks about a test that will verify this. We are running their `sanity` tests already, and it doesn't seem to check this for us.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #164
