### PR TITLE
(#177) Ensure we're testing against Ansible 2.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,5 @@ See [LICENSE](LICENSE) to see full text.
 
 <!-- Link Targets -->
 
-[pipeline-link]: https://dev.azure.com/ChocolateyCI/Chocolatey-Ansible/_build/latest?definitionId=2&branchName=master
+[pipeline-link]: https://dev.azure.com/ChocolateyCI/Chocolatey-Ansible/_build/latest?definitionId=3&branchName=master
 [pipeline-badge]: https://dev.azure.com/ChocolateyCI/Chocolatey-Ansible/_apis/build/status/Chocolatey%20Collection%20CI?branchName=master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
     pool:
       vmImage: ubuntu-latest
     variables:
-      Ansible.Package: "ansible-core==2.17"
+      Ansible.Package: "ansible-core==2.18"
 
     steps:
     - task: Bash@3
@@ -131,18 +131,22 @@ stages:
     strategy:
       maxParallel: 1
       matrix:
-        ansible216:
-          Ansible.Package: "ansible-core==2.16"
-          Ansible.Version: "2.16"
         ansible217:
           Ansible.Package: "ansible-core==2.17"
           Ansible.Version: "2.17"
         ansible218:
           Ansible.Package: "ansible-core==2.18"
           Ansible.Version: "2.18"
+        ansible219:
+          Ansible.Package: "ansible-core==2.19"
+          Ansible.Version: "2.19"
         ansible-latest:
           Ansible.Package: "ansible-core"
           Ansible.Version: "latest"
+        ansible-prerelease:
+          Ansible.Package: "ansible-core"
+          Ansible.Prerelease: "1"
+          Ansible.Version: "prerelease"
 
     steps:
     - task: DownloadPipelineArtifact@2

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -23,7 +23,13 @@ pip3 install --upgrade pip
 pip3 install --upgrade wheel
 pip3 install packaging
 pip3 install "Jinja2~=3.1.3"
-pip3 install "$ANSIBLE_PACKAGE"
+
+# if pipeline calls for it, pull prerelease if available
+if [ $ANSIBLE_PRERELEASE == '1' ]; then
+    pip3 install --pre "$ANSIBLE_PACKAGE"
+else
+    pip3 install "$ANSIBLE_PACKAGE"
+fi
 
 ansible-galaxy collection install ansible.windows
 


### PR DESCRIPTION
## Description Of Changes

- Added 2.19 to the ansible-core versions we're explicitly testing
- Updated the ansible version used to *build* the collection to 2.18 (latest current stable according to [the lifecycle page](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix)
- Also, updated an outdated link in the README that was being used for the pipeline status badge.
- Amended the `dependencies.sh` script to allow `pip3` to pull in a prerelease version for `ansible-core` with no version specified, so it pulls the actual latest, and a matching pipeline configuration that calls for a prerelease version.

## Motivation and Context
See #177; we need this testing to be explicitly done to validate compatibility and ensure inclusion with the community package shipped with Ansible 12.

## Testing

Testing in CI.

### Operating Systems Testing

Win10, Ubuntu

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #177
