### PR TITLE
(maint) Use latest patch version of ansible-core in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
     pool:
       vmImage: ubuntu-latest
     variables:
-      Ansible.Package: "ansible-core==2.18"
+      Ansible.Package: "ansible-core~=2.18.0"
 
     steps:
     - task: Bash@3
@@ -132,13 +132,13 @@ stages:
       maxParallel: 1
       matrix:
         ansible217:
-          Ansible.Package: "ansible-core==2.17"
+          Ansible.Package: "ansible-core~=2.17.0"
           Ansible.Version: "2.17"
         ansible218:
-          Ansible.Package: "ansible-core==2.18"
+          Ansible.Package: "ansible-core~=2.18.0"
           Ansible.Version: "2.18"
         ansible219:
-          Ansible.Package: "ansible-core==2.19"
+          Ansible.Package: "ansible-core~=2.19.0"
           Ansible.Version: "2.19"
         ansible-latest:
           Ansible.Package: "ansible-core"
@@ -322,7 +322,7 @@ stages:
   - Test
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
   variables:
-    Ansible.Package: 'ansible-core==2.18'
+    Ansible.Package: 'ansible-core~=2.18.0'
 
   jobs:
   - job: Publish


### PR DESCRIPTION
## Description Of Changes
- Use `~=` "compatible version" specifiers instead of exact version requirements in our CI.

## Motivation and Context

Previously we used `==` which would not match newer patch versions (so `==2.18` would only match `2.18.0`), which means we didn't test on the latest available patch for that release version.

Per https://packaging.python.org/en/latest/specifications/version-specifiers/#id5 we can use `~=X.X.0` to take the latest patch version of `X.X` release.

This fixes the problem where certain `X.X.0` versions of ansible-core are not always available and we still test against that minor version correctly. This hasn't happened recently but we should ensure our CI is testing on the latest patch versions for each minor version.

## Testing
CI testing runs, we should get the latest available patch version for each ansible-core minor version we're testing against.

### Operating Systems Testing
N/A
## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A