### PR TITLE
(#173) Add support for --ignore-pinned switch

### DIFF
--- a/chocolatey/plugins/module_utils/Packages.psm1
+++ b/chocolatey/plugins/module_utils/Packages.psm1
@@ -325,6 +325,11 @@ function ConvertTo-ChocolateyArgument {
         [switch]
         $IgnoreDependencies,
 
+        # Set to ignore any pins and upgrades the package(s) anyway.
+        [Parameter()]
+        [switch]
+        $IgnorePinned,
+
         # Installation args to be provided to installers in a given package.
         [Parameter()]
         [string]
@@ -405,6 +410,7 @@ function ConvertTo-ChocolateyArgument {
     if ($Force) { "--force" }
     if ($IgnoreChecksums) { "--ignore-checksums" }
     if ($IgnoreDependencies) { "--ignore-dependencies" }
+    if ($IgnorePinned) { "--ignore-pinned" }
     if ($InstallArgs) { "--install-arguments", $InstallArgs }
     if ($OverrideArgs) { "--override-arguments" }
     if ($PackageParams) { "--package-parameters", $PackageParams }
@@ -621,6 +627,11 @@ function Update-ChocolateyPackage {
         [Parameter()]
         [switch]
         $IgnoreDependencies,
+
+        # Set to ignore any pins and upgrades the package(s) anyway.
+        [Parameter()]
+        [switch]
+        $IgnorePinned,
 
         # Installation args to be provided to installers in a given package.
         [Parameter()]

--- a/chocolatey/plugins/modules/win_chocolatey.ps1
+++ b/chocolatey/plugins/modules/win_chocolatey.ps1
@@ -49,6 +49,7 @@ function Get-ModuleSpec {
             force                 = @{ type = "bool"; default = $false }
             ignore_checksums      = @{ type = "bool"; default = $false }
             ignore_dependencies   = @{ type = "bool"; default = $false }
+            ignore_pinned         = @{ type = "bool"; default = $false }
             install_args          = @{ type = "str" }
             name                  = @{ type = "list"; elements = "str"; required = $true }
             override_args         = @{ type = "bool"; default = $false }
@@ -89,6 +90,7 @@ $choco_args = $module.Params.choco_args
 $force = $module.Params.force
 $ignore_checksums = $module.Params.ignore_checksums
 $ignore_dependencies = $module.Params.ignore_dependencies
+$ignore_pinned = $module.Params.ignore_pinned
 $install_args = $module.Params.install_args
 $name = $module.Params.name
 $override_args = $module.Params.override_args
@@ -153,6 +155,10 @@ $module.Result.choco_cli_version = "$chocolateyVersion"
 
 if ($chocolateyVersion -ge [version]'2.0.0' -and $allow_multiple) {
     Assert-TaskFailed -Message "Option 'allow_multiple' is not supported on the installed version of Chocolatey CLI"
+}
+
+if ($chocolateyVersion -lt [version]'2.3.0' -and $ignore_pinned) {
+    Assert-TaskFailed -Message "Option 'ignore_pinned' is not supported on the installed version of Chocolatey CLI"
 }
 
 if ($state -in "absent", "reinstalled") {
@@ -249,6 +255,7 @@ if ($state -in @("downgrade", "latest", "upgrade", "present", "reinstalled")) {
         Force = $force
         IgnoreChecksums = $ignore_checksums
         IgnoreDependencies = $ignore_dependencies
+        IgnorePinned = $ignore_pinned
         InstallArgs = $install_args
         OverrideArgs = $override_args
         PackageParams = $package_params

--- a/chocolatey/plugins/modules/win_chocolatey.py
+++ b/chocolatey/plugins/modules/win_chocolatey.py
@@ -146,6 +146,13 @@ options:
     type: bool
     default: false
     version_added: '0.2.1'
+  ignore_pinned:
+    description:
+    - Ignores any pins and upgrades the package(s) anyway.
+    - Chocolatey CLI (choco) v2.3.0 and higher is required to use this option.
+    type: bool
+    default: false
+    version_added: '1.6.0'
   remove_dependencies:
     description:
     - Remove a package's dependencies on uninstall.

--- a/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
+++ b/chocolatey/tests/integration/targets/win_chocolatey/tasks/tests.yml
@@ -714,3 +714,40 @@
     - (checksum_actual_info.stdout|from_json).checksum_type == "sha1"
     - (checksum_actual_info.stdout|from_json).checksum64 == "a3a1f075f5b0e9ee7cd2ba33afbb5f67b9e335117ef3ea352fc361b098aecad4"
     - (checksum_actual_info.stdout|from_json).checksum_type64 == "sha256"
+
+- name: ensure test package is not installed
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: absent
+
+- name: install test package and pin it
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: present
+    version: '0.0.1'
+    pinned: yes
+
+- name: attempt upgrade of pinned package
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: latest
+  register: pinned_upgrade
+
+- name: assert upgrade of pinned package made no changes
+  assert:
+    that:
+    - pinned_upgrade is not changed
+    - pinned_upgrade is not failed
+
+- name: attempt upgrade of pinned package ignoring the pin
+  win_chocolatey:
+    name: '{{ test_choco_package1 }}'
+    state: latest
+    ignore_pinned: true
+  register: ignore_pinned_upgrade
+
+- name: assert upgrade of pinned package succeeded
+  assert:
+    that:
+    - ignore_pinned_upgrade is changed
+    - ignore_pinned_upgrade is not failed


### PR DESCRIPTION
## Description Of Changes

Adds support for the `--ignore-pinned` switch that was added to Chocolatey CLI in v2.3.0.

## Motivation and Context

This option allows for upgrading pinned packages without needing to go through the process of unpinning, upgrading, and then repinning said package.

As Chocolatey CLI v2.3.0 is required, the task will fail if an unsupported version of Chocolatey CLI is found on the client.

Tests have also been added to cover this change.

## Testing

```yaml
- name: ensure test package is not installed
  win_chocolatey:
    name: '{{ test_choco_package1 }}'
    state: absent

- name: install test package and pin it
  win_chocolatey:
    name: '{{ test_choco_package1 }}'
    state: present
    version: '0.0.1'
    pinned: yes

- name: attempt upgrade of pinned package
  win_chocolatey:
    name: '{{ test_choco_package1 }}'
    state: latest
  register: pinned_upgrade

- name: assert upgrade of pinned package made no changes
  assert:
    that:
    - pinned_upgrade is not changed
    - pinned_upgrade is not failed

- name: attempt upgrade of pinned package ignoring the pin
  win_chocolatey:
    name: '{{ test_choco_package1 }}'
    state: latest
    ignore_pinned: true
  register: ignore_pinned_upgrade

- name: assert upgrade of pinned package succeeded
  assert:
    that:
    - ignore_pinned_upgrade is changed
    - ignore_pinned_upgrade is not failed
```

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [X] Requires a change to the documentation.
* [X] Documentation has been updated.
* [X] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #173
